### PR TITLE
Add fuzzy search

### DIFF
--- a/src/main/java/mycelium/mycelium/model/FuzzyManager.java
+++ b/src/main/java/mycelium/mycelium/model/FuzzyManager.java
@@ -1,0 +1,59 @@
+package mycelium.mycelium.model;
+
+import java.util.logging.Logger;
+
+import mycelium.mycelium.commons.core.LogsCenter;
+import mycelium.mycelium.model.util.Fuzzy;
+import mycelium.mycelium.ui.MainWindow;
+import mycelium.mycelium.ui.commandbox.CommandBox;
+
+/**
+ * This class is responsible for handling fuzzy matching of clients and projects.
+ */
+public class FuzzyManager implements CommandBox.CommandInputListener {
+    private static final Logger logger = LogsCenter.getLogger(FuzzyManager.class);
+    private final ReadOnlyAddressBook addressBook;
+
+    /**
+     * Initializes a FuzzyManager with the given address book.
+     *
+     * @param addressBook the address book to use for fuzzy matching.
+     */
+    public FuzzyManager(ReadOnlyAddressBook addressBook) {
+        this.addressBook = addressBook;
+    }
+
+    @Override
+    public void onInputChanged(String rawInput, MainWindow mainWindow) {
+        if (rawInput.isEmpty()) {
+            mainWindow.setClients(addressBook.getClientList());
+            mainWindow.setProjects(addressBook.getProjectList());
+            return;
+        }
+        logger.info("Received fuzzy match request for: " + rawInput);
+
+        // The two lists we get here from the address book are immutable references. So we can do whatever with them
+        // and not worry about messing up the address book's state.
+        //
+        // NOTE(jy): this is very inefficient, but it is simple and gets the job done for now.
+
+        var input = rawInput.toLowerCase();
+        var clients = addressBook.getClientList()
+            .filtered(client -> Fuzzy.deltaPercent(input, client.getName().toString().toLowerCase()) > 0.0)
+            .sorted((client1, client2) -> {
+                var delta1 = Fuzzy.deltaPercent(input, client1.getName().toString().toLowerCase());
+                var delta2 = Fuzzy.deltaPercent(input, client2.getName().toString().toLowerCase());
+                return Double.compare(delta2, delta1);
+            });
+        var projects = addressBook.getProjectList()
+            .filtered(project -> Fuzzy.deltaPercent(input, project.getName().toString().toLowerCase()) > 0.0)
+            .sorted((project1, project2) -> {
+                var delta1 = Fuzzy.deltaPercent(input, project1.getName().toString().toLowerCase());
+                var delta2 = Fuzzy.deltaPercent(input, project2.getName().toString().toLowerCase());
+                return Double.compare(delta2, delta1);
+            });
+
+        mainWindow.setClients(clients);
+        mainWindow.setProjects(projects);
+    }
+}

--- a/src/main/java/mycelium/mycelium/model/FuzzyManager.java
+++ b/src/main/java/mycelium/mycelium/model/FuzzyManager.java
@@ -2,7 +2,10 @@ package mycelium.mycelium.model;
 
 import java.util.logging.Logger;
 
+import javafx.collections.transformation.SortedList;
 import mycelium.mycelium.commons.core.LogsCenter;
+import mycelium.mycelium.model.client.Client;
+import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.ui.MainWindow;
 import mycelium.mycelium.ui.commandbox.CommandBox;
 
@@ -36,10 +39,10 @@ public class FuzzyManager implements CommandBox.CommandInputListener {
         //
         // NOTE(jy): this is very inefficient, but it is simple and gets the job done for now.
 
-        var clients = addressBook.getClientList()
+        SortedList<Client> clients = addressBook.getClientList()
             .filtered(cli -> cli.fuzzyCompareTo(input) > 0.0)
             .sorted((cli1, cli2) -> Double.compare(cli2.fuzzyCompareTo(input), cli1.fuzzyCompareTo(input)));
-        var projects = addressBook.getProjectList()
+        SortedList<Project> projects = addressBook.getProjectList()
             .filtered(proj -> proj.fuzzyCompareTo(input) > 0.0)
             .sorted((proj1, proj2) -> Double.compare(proj2.fuzzyCompareTo(input), proj1.fuzzyCompareTo(input)));
 

--- a/src/main/java/mycelium/mycelium/model/client/Client.java
+++ b/src/main/java/mycelium/mycelium/model/client/Client.java
@@ -148,7 +148,8 @@ public class Client implements IsSame<Client>, FuzzyComparable<String> {
     }
 
     @Override
-    public double fuzzyCompareTo(String name) {
-        return Fuzzy.deltaPercent(name.toString(), name);
+    public double fuzzyCompareTo(String match) {
+        var ret = Fuzzy.deltaPercent(name.toString().toLowerCase(), match.toLowerCase());
+        return ret;
     }
 }

--- a/src/main/java/mycelium/mycelium/model/client/Client.java
+++ b/src/main/java/mycelium/mycelium/model/client/Client.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import mycelium.mycelium.model.person.Email;
 import mycelium.mycelium.model.person.Name;
 import mycelium.mycelium.model.person.Phone;
+import mycelium.mycelium.model.util.Fuzzy;
+import mycelium.mycelium.model.util.FuzzyComparable;
 import mycelium.mycelium.model.util.IsSame;
 import mycelium.mycelium.model.util.NonEmptyString;
 
@@ -15,7 +17,7 @@ import mycelium.mycelium.model.util.NonEmptyString;
  * A client can be created with just a name and email or with all available information.
  * The name and email are required fields and cannot be null.
  */
-public class Client implements IsSame<Client> {
+public class Client implements IsSame<Client>, FuzzyComparable<String> {
     private final Name name;
 
     private final Email email;
@@ -143,5 +145,10 @@ public class Client implements IsSame<Client> {
     @Override
     public String toString() {
         return String.format("%s (%s)", name, email);
+    }
+
+    @Override
+    public double fuzzyCompareTo(String name) {
+        return Fuzzy.deltaPercent(name.toString(), name);
     }
 }

--- a/src/main/java/mycelium/mycelium/model/client/Client.java
+++ b/src/main/java/mycelium/mycelium/model/client/Client.java
@@ -149,7 +149,7 @@ public class Client implements IsSame<Client>, FuzzyComparable<String> {
 
     @Override
     public double fuzzyCompareTo(String match) {
-        var ret = Fuzzy.deltaPercent(name.toString().toLowerCase(), match.toLowerCase());
+        var ret = Fuzzy.ratio(name.toString().toLowerCase(), match.toLowerCase());
         return ret;
     }
 }

--- a/src/main/java/mycelium/mycelium/model/project/Project.java
+++ b/src/main/java/mycelium/mycelium/model/project/Project.java
@@ -158,8 +158,8 @@ public class Project implements IsSame<Project>, FuzzyComparable<String> {
     }
 
     @Override
-    public double fuzzyCompareTo(String name) {
-        return Fuzzy.deltaPercent(name.toString(), name);
+    public double fuzzyCompareTo(String match) {
+        return Fuzzy.deltaPercent(name.toString().toLowerCase(), match.toLowerCase());
     }
 }
 

--- a/src/main/java/mycelium/mycelium/model/project/Project.java
+++ b/src/main/java/mycelium/mycelium/model/project/Project.java
@@ -6,13 +6,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 import mycelium.mycelium.model.person.Email;
+import mycelium.mycelium.model.util.Fuzzy;
+import mycelium.mycelium.model.util.FuzzyComparable;
 import mycelium.mycelium.model.util.IsSame;
 import mycelium.mycelium.model.util.NonEmptyString;
 
 /**
  * Represents a project.
  */
-public class Project implements IsSame<Project> {
+public class Project implements IsSame<Project>, FuzzyComparable<String> {
     public static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
     /**
@@ -153,6 +155,11 @@ public class Project implements IsSame<Project> {
     @Override
     public String toString() {
         return String.format("%s from client %s", name, clientEmail);
+    }
+
+    @Override
+    public double fuzzyCompareTo(String name) {
+        return Fuzzy.deltaPercent(name.toString(), name);
     }
 }
 

--- a/src/main/java/mycelium/mycelium/model/project/Project.java
+++ b/src/main/java/mycelium/mycelium/model/project/Project.java
@@ -159,7 +159,7 @@ public class Project implements IsSame<Project>, FuzzyComparable<String> {
 
     @Override
     public double fuzzyCompareTo(String match) {
-        return Fuzzy.deltaPercent(name.toString().toLowerCase(), match.toLowerCase());
+        return Fuzzy.ratio(name.toString().toLowerCase(), match.toLowerCase());
     }
 }
 

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -92,7 +92,7 @@ public class Fuzzy {
      * <p>
      * Note that this method will not modify the original list. It is a pure function and safe to call multiple times.
      */
-    public static <T extends FuzzyComparable<String>> List<T> fuzzySearch(List<T> list, String query) {
+    public static <S, T extends FuzzyComparable<S>> List<T> fuzzySearch(List<T> list, S query) {
         ArrayList<T> xs = new ArrayList<>(list);
         // This is not very efficient, but it's simple and it works
         xs.sort((a, b) -> Double.compare(b.fuzzyCompareTo(query), a.fuzzyCompareTo(query)));

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -1,0 +1,65 @@
+package mycelium.mycelium.model.util;
+
+/**
+ * A utility class for fuzzy string matching.
+ */
+public class Fuzzy {
+
+    /**
+     * Computes a "delta-score" between two strings. The lower the score, the more similar the strings are. A score
+     * of zero means the strings are completely identical.
+     */
+    public static int delta(String a, String b) {
+        // The intuitive way to do this is through a m-by-n matrix. Here we are only
+        // using one array and a temp variable.
+        int m = a.length(), n = b.length();
+        if (m > n) {
+            String tmp = a;
+            a = b;
+            b = tmp;
+
+            int _tmp = m;
+            m = n;
+            n = _tmp;
+        }
+        if (m == 0) {
+            return n;
+        }
+        if (m == 1) {
+            char c = a.charAt(0);
+            for (int i = 0; i < n; i++) {
+                if (b.charAt(i) == c) {
+                    return n - 1;
+                }
+            }
+            return n;
+        }
+
+        int[] prevRow = new int[b.length() + 1];
+
+        for (int j = 0; j < n + 1; j++) {
+            prevRow[j] = j;
+        }
+
+        int grave, ifDelete, ifInsert, tmp;
+        for (int i = 0; i < m; i++) {
+            grave = i; // grave refers to the upper-left tile (from the matrix POV)
+            prevRow[0] = i + 1; // the first entry is always i+1
+
+            // now fill in 1..n+1 entries, writing to index j+1 for each iteration
+            for (int j = 0; j < n; j++) {
+                tmp = grave;
+                if (a.charAt(i) != b.charAt(j)) {
+                    ifDelete = prevRow[j + 1];
+                    ifInsert = prevRow[j]; // this is technically "currentRow[j]"
+                    tmp = ifInsert < grave ? ifInsert : grave;
+                    tmp = ifDelete < tmp ? ifDelete : tmp;
+                    tmp += 1;
+                }
+                grave = prevRow[j + 1];
+                prevRow[j + 1] = tmp;
+            }
+        }
+        return prevRow[n];
+    }
+}

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -1,5 +1,9 @@
 package mycelium.mycelium.model.util;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * A utility class for fuzzy string matching.
  */
@@ -79,5 +83,19 @@ public class Fuzzy {
      */
     public static double deltaPercent(String a, String b) {
         return 1 - (double) delta(a, b) / Math.max(a.length(), b.length());
+    }
+
+    /**
+     * Performs a fuzzy search on a list of objects against some query string. Objects which are more similar to the
+     * query string will be at the front of the returned list. Objects which are completely different will not be
+     * included in the returned list.
+     * <p>
+     * Note that this method will not modify the original list. It is a pure function and safe to call multiple times.
+     */
+    public static <T extends FuzzyComparable<String>> List<T> fuzzySearch(List<T> list, String query) {
+        ArrayList<T> xs = new ArrayList<>(list);
+        // This is not very efficient, but it's simple and it works
+        xs.sort((a, b) -> Double.compare(b.fuzzyCompareTo(query), a.fuzzyCompareTo(query)));
+        return xs.stream().filter(x -> x.fuzzyCompareTo(query) > 0.0).collect(Collectors.toList());
     }
 }

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -1,9 +1,5 @@
 package mycelium.mycelium.model.util;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 /**
  * A utility class for fuzzy string matching.
  */
@@ -83,19 +79,5 @@ public class Fuzzy {
      */
     public static double deltaPercent(String a, String b) {
         return 1 - (double) delta(a, b) / Math.max(a.length(), b.length());
-    }
-
-    /**
-     * Performs a fuzzy search on a list of objects against some query string. Objects which are more similar to the
-     * query string will be at the front of the returned list. Objects which are completely different will not be
-     * included in the returned list.
-     * <p>
-     * Note that this method will not modify the original list. It is a pure function and safe to call multiple times.
-     */
-    public static <S, T extends FuzzyComparable<S>> List<T> fuzzySearch(List<T> list, S query) {
-        ArrayList<T> xs = new ArrayList<>(list);
-        // This is not very efficient, but it's simple and it works
-        xs.sort((a, b) -> Double.compare(b.fuzzyCompareTo(query), a.fuzzyCompareTo(query)));
-        return xs.stream().filter(x -> x.fuzzyCompareTo(query) > 0.0).collect(Collectors.toList());
     }
 }

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -12,15 +12,16 @@ public class Fuzzy {
     public static int delta(String a, String b) {
         // The intuitive way to do this is through a m-by-n matrix. Here we are only
         // using one array and a temp variable.
-        int m = a.length(), n = b.length();
+        int m = a.length();
+        int n = b.length();
         if (m > n) {
             String tmp = a;
             a = b;
             b = tmp;
 
-            int _tmp = m;
+            int tmp2 = m;
             m = n;
-            n = _tmp;
+            n = tmp2;
         }
         if (m == 0) {
             return n;
@@ -41,7 +42,10 @@ public class Fuzzy {
             prevRow[j] = j;
         }
 
-        int grave, ifDelete, ifInsert, tmp;
+        int grave;
+        int ifDelete;
+        int ifInsert;
+        int tmp;
         for (int i = 0; i < m; i++) {
             grave = i; // grave refers to the upper-left tile (from the matrix POV)
             prevRow[0] = i + 1; // the first entry is always i+1

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -77,7 +77,7 @@ public class Fuzzy {
      * Computes a "delta-score" between two strings, and returns a value between 0 and 1, where 0 means the two strings
      * are completely different, and 1 means they are completely the same.
      */
-    public static double deltaPercent(String a, String b) {
+    public static double ratio(String a, String b) {
         return 1 - (double) delta(a, b) / Math.max(a.length(), b.length());
     }
 }

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -23,6 +23,10 @@ public class Fuzzy {
             m = n;
             n = tmp2;
         }
+
+        // From here on, `b` is the longer string, and `a` is the shorter string. Accordingly, `n` is the size of the
+        // longer string, and `m` is the size of the shorter string.
+
         if (m == 0) {
             return n;
         }
@@ -36,7 +40,9 @@ public class Fuzzy {
             return n;
         }
 
-        int[] prevRow = new int[b.length() + 1];
+        // NOTE: if we know the max size of the strings beforehand, we can pre-allocate the array, and re-use it for
+        // every call. There is no need to clear the array, since we are only ever writing to it.
+        int[] prevRow = new int[n + 1];
 
         for (int j = 0; j < n + 1; j++) {
             prevRow[j] = j;
@@ -65,5 +71,13 @@ public class Fuzzy {
             }
         }
         return prevRow[n];
+    }
+
+    /**
+     * Computes a "delta-score" between two strings, and returns a value between 0 and 1, where 0 means the two strings
+     * are completely different, and 1 means they are completely the same.
+     */
+    public static double deltaPercent(String a, String b) {
+        return 1 - (double) delta(a, b) / Math.max(a.length(), b.length());
     }
 }

--- a/src/main/java/mycelium/mycelium/model/util/FuzzyComparable.java
+++ b/src/main/java/mycelium/mycelium/model/util/FuzzyComparable.java
@@ -1,0 +1,18 @@
+package mycelium.mycelium.model.util;
+
+/**
+ * An interface for objects that can be compared in a fuzzy way. Somewhat analogous to {@code Comparable}, but
+ * instead of returning an integer, it returns a double between 0 and 1.
+ *
+ * @param <T> The type of the object to compare to.
+ */
+public interface FuzzyComparable<T> {
+    /**
+     * Returns a value between 0 and 1, where 0 means the two objects are
+     * completely different, and 1 means they are completely the same.
+     *
+     * @param other The other object to compare to.
+     * @return A value between 0 and 1.
+     */
+    double fuzzyCompareTo(T other);
+}

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedClient.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedClient.java
@@ -50,7 +50,6 @@ class JsonAdaptedClient {
      * Converts a given {@code Client} into this class for Jackson use.
      */
     public JsonAdaptedClient(Client client) {
-        System.out.println(client);
         name = client.getName().fullName;
         email = client.getEmail().value;
         yearOfBirth = client.getYearOfBirth().map(x -> x.value).orElse(null);

--- a/src/main/java/mycelium/mycelium/ui/MainWindow.java
+++ b/src/main/java/mycelium/mycelium/ui/MainWindow.java
@@ -2,6 +2,7 @@ package mycelium.mycelium.ui;
 
 import java.util.logging.Logger;
 
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
 import javafx.scene.layout.StackPane;
@@ -13,6 +14,9 @@ import mycelium.mycelium.logic.commands.CommandResult;
 import mycelium.mycelium.logic.commands.exceptions.CommandException;
 import mycelium.mycelium.logic.parser.exceptions.ParseException;
 import mycelium.mycelium.logic.uievent.UiEventManager;
+import mycelium.mycelium.model.FuzzyManager;
+import mycelium.mycelium.model.client.Client;
+import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.ui.commandbox.CommandBox;
 import mycelium.mycelium.ui.commandlog.CommandLog;
 import mycelium.mycelium.ui.entitypanel.EntityPanel;
@@ -36,6 +40,7 @@ public class MainWindow extends UiPart<Stage> {
     private HelpWindow helpWindow;
     private CommandBox commandBox;
     private CommandLog commandLog;
+
     private EntityPanel entityPanel;
     private StatusBarFooter statusBarFooter;
 
@@ -95,12 +100,12 @@ public class MainWindow extends UiPart<Stage> {
         logger.info("Filling inner parts of MainWindow...");
         helpWindow = new HelpWindow();
 
-        commandBox = new CommandBox(
-            this::executeCommand, (String input) -> {
-                System.out.println("Input: " + input);
-            }
-        // TO BE REPLACED WITH FUZZY SEARCH
-        );
+        commandBox =
+            new CommandBox(this, this::executeCommand, new FuzzyManager(logic.getAddressBook()), (mainWindow) -> {
+            }, (mainWindow) -> {
+                mainWindow.setClients(logic.getFilteredClientList());
+                mainWindow.setProjects(logic.getFilteredProjectList());
+            });
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
         commandLog = new CommandLog();
@@ -176,5 +181,20 @@ public class MainWindow extends UiPart<Stage> {
             commandLog.setFeedbackToUser(e.getMessage());
             throw e;
         }
+    }
+
+
+    /**
+     * Sets the clients in the entity panel.
+     */
+    public void setClients(ObservableList<Client> list) {
+        entityPanel.setClients(list);
+    }
+
+    /**
+     * Sets the projects in the entity panel.
+     */
+    public void setProjects(ObservableList<Project> list) {
+        entityPanel.setProjects(list);
     }
 }

--- a/src/main/java/mycelium/mycelium/ui/MainWindow.java
+++ b/src/main/java/mycelium/mycelium/ui/MainWindow.java
@@ -103,6 +103,7 @@ public class MainWindow extends UiPart<Stage> {
         commandBox =
             new CommandBox(this, this::executeCommand, new FuzzyManager(logic.getAddressBook()), (mainWindow) -> {
             }, (mainWindow) -> {
+                // Just to "reset" the lists back to its state in the address book.
                 mainWindow.setClients(logic.getFilteredClientList());
                 mainWindow.setProjects(logic.getFilteredProjectList());
             });

--- a/src/main/java/mycelium/mycelium/ui/entitypanel/EntityList.java
+++ b/src/main/java/mycelium/mycelium/ui/entitypanel/EntityList.java
@@ -52,6 +52,17 @@ public class EntityList<T> extends UiPart<Region> {
     }
 
     /**
+     * Replaces the contents of the list panel with the given list.
+     *
+     * @param list The new list to display.
+     */
+    public void setItems(ObservableList<T> list) {
+        requireNonNull(list);
+        listView.setItems(list);
+        logger.fine("Reset list panel with " + list.size() + " items");
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code T}.
      */
     class ListViewCell extends ListCell<T> {

--- a/src/main/java/mycelium/mycelium/ui/entitypanel/EntityPanel.java
+++ b/src/main/java/mycelium/mycelium/ui/entitypanel/EntityPanel.java
@@ -17,6 +17,9 @@ import mycelium.mycelium.ui.UiPart;
 public class EntityPanel extends UiPart<TabPane> {
     private static final String FXML = "EntityPanel.fxml";
     private Logger logger = LogsCenter.getLogger(getClass());
+
+
+
     private EntityList<Client> clientListPanel;
     private EntityList<Project> projectListPanel;
     private EntityTab projectTab;
@@ -26,8 +29,6 @@ public class EntityPanel extends UiPart<TabPane> {
 
     /**
      * Initialises a {@code EntityPanel} with a given {@code Logic}.
-     *
-     * @param logic Logic to be used by the EntityPanel
      */
     public EntityPanel(ObservableList<Project> projectList, ObservableList<Client> clientList) {
         super(FXML);
@@ -63,5 +64,19 @@ public class EntityPanel extends UiPart<TabPane> {
         int size = this.tabs.size();
         int i = this.selectionModel.getSelectedIndex();
         this.selectionModel.select((i + 1) % size);
+    }
+
+    /**
+     * Sets the clients in the client list panel.
+     */
+    public void setClients(ObservableList<Client> list) {
+        clientListPanel.setItems(list);
+    }
+
+    /**
+     * Sets the projects in the project list panel.
+     */
+    public void setProjects(ObservableList<Project> list) {
+        projectListPanel.setItems(list);
     }
 }

--- a/src/main/java/mycelium/mycelium/ui/entitypanel/EntityPanel.java
+++ b/src/main/java/mycelium/mycelium/ui/entitypanel/EntityPanel.java
@@ -17,9 +17,6 @@ import mycelium.mycelium.ui.UiPart;
 public class EntityPanel extends UiPart<TabPane> {
     private static final String FXML = "EntityPanel.fxml";
     private Logger logger = LogsCenter.getLogger(getClass());
-
-
-
     private EntityList<Client> clientListPanel;
     private EntityList<Project> projectListPanel;
     private EntityTab projectTab;

--- a/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
+++ b/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
@@ -13,32 +13,34 @@ class FuzzyTest {
     private static class Case {
         public final String a;
         public final String b;
-        public final int expected;
-        public final String desc;
+        public final int expectedDelta;
+        public final double expectedPercent;
 
-        Case(String a, String b, int expected, String desc) {
+        Case(String a, String b, int expectedDelta, double expectedPercent) {
             this.a = a;
             this.b = b;
-            this.expected = expected;
-            this.desc = desc;
+            this.expectedDelta = expectedDelta;
+            this.expectedPercent = expectedPercent;
         }
     }
 
     @Test
     void delta() {
+        // NOTE: we are testing both delta and percent here, because they are so closely related.
         Case[] tests = {
-            new Case("uwu", "owo", 2, "replace only"),
-            new Case("horse", "ros", 3, "replace with insert"),
-            new Case("intention", "execution", 5, "replace with insert"),
-            new Case("uwu", "", 3, "RHS empty"),
-            new Case("", "uwu", 3, "LHS empty"),
-            new Case("   ", "uwu", 3, "whitespace"),
-            new Case("uwu", "uwu", 0, "same strings")
+            new Case("uwu", "owo", 2, 2 / (double) 3),
+            new Case("horse", "ros", 3, 3 / (double) 5),
+            new Case("intention", "execution", 5, 5 / (double) 9),
+            new Case("uwu", "", 3, 1),
+            new Case("", "uwu", 3, 1),
+            new Case("   ", "uwu", 3, 1),
+            new Case("foo", "baz bat", 7, 1),
+            new Case("uwu", "uwu", 0, 0)
         };
 
         for (Case test : tests) {
             int actual = Fuzzy.delta(test.a, test.b);
-            assertEquals(test.expected, actual, "While testing case: " + test.desc);
+            assertEquals(test.expectedDelta, actual, "While testing case: " + test.a + ", " + test.b);
         }
     }
 }

--- a/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
+++ b/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
@@ -1,0 +1,48 @@
+package mycelium.mycelium.model.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import mycelium.mycelium.testutil.Pair;
+
+class FuzzyTest {
+
+    /**
+     * A test case for the delta function.
+     */
+    private static class Case {
+        String a;
+        String b;
+        int expected;
+        String desc;
+
+        Case(String a, String b, int expected, String desc) {
+            this.a = a;
+            this.b = b;
+            this.expected = expected;
+            this.desc = desc;
+        }
+    }
+
+    @Test
+    void delta() {
+        Case[] tests = {
+            new Case("uwu", "owo", 2, "replace only"),
+            new Case("horse", "ros", 3, "replace with insert"),
+            new Case("intention", "execution", 5, "replace with insert"),
+            new Case("uwu", "", 3, "RHS empty"),
+            new Case("", "uwu", 3, "LHS empty"),
+            new Case("   ", "uwu", 3, "whitespace"),
+            new Case("uwu", "uwu", 0, "same strings")
+        };
+
+        for (Case test : tests) {
+            int actual = Fuzzy.delta(test.a, test.b);
+            assertEquals(test.expected, actual, "While testing case: " + test.desc);
+        }
+    }
+
+}

--- a/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
+++ b/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
@@ -1,12 +1,9 @@
 package mycelium.mycelium.model.util;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import mycelium.mycelium.testutil.Pair;
 
 class FuzzyTest {
 
@@ -14,10 +11,10 @@ class FuzzyTest {
      * A test case for the delta function.
      */
     private static class Case {
-        String a;
-        String b;
-        int expected;
-        String desc;
+        public final String a;
+        public final String b;
+        public final int expected;
+        public final String desc;
 
         Case(String a, String b, int expected, String desc) {
             this.a = a;
@@ -44,5 +41,4 @@ class FuzzyTest {
             assertEquals(test.expected, actual, "While testing case: " + test.desc);
         }
     }
-
 }

--- a/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
+++ b/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
@@ -6,41 +6,47 @@ import org.junit.jupiter.api.Test;
 
 
 class FuzzyTest {
-
     /**
      * A test case for the delta function.
      */
-    private static class Case {
-        public final String a;
-        public final String b;
+    private static class TestCase {
+        public final String s1;
+        public final String s2;
         public final int expectedDelta;
-        public final double expectedPercent;
+        public final double expectedRatio;
 
-        Case(String a, String b, int expectedDelta, double expectedPercent) {
-            this.a = a;
-            this.b = b;
+        TestCase(String s1, String s2, int expectedDelta, double expectedRatio) {
+            this.s1 = s1;
+            this.s2 = s2;
             this.expectedDelta = expectedDelta;
-            this.expectedPercent = expectedPercent;
+            this.expectedRatio = expectedRatio;
+        }
+    }
+
+    private static final TestCase[] testCases = {
+        new TestCase("uwu", "owo", 2, 1 / (double) 3),
+        new TestCase("horse", "ros", 3, 2 / (double) 5),
+        new TestCase("intention", "execution", 5, 4 / (double) 9),
+        new TestCase("uwu", "", 3, 0),
+        new TestCase("", "uwu", 3, 0),
+        new TestCase("   ", "uwu", 3, 0),
+        new TestCase("foo", "baz bat", 7, 0),
+        new TestCase("uwu", "uwu", 0, 1)
+    };
+
+    @Test
+    void delta() {
+        for (TestCase test : testCases) {
+            int actual = Fuzzy.delta(test.s1, test.s2);
+            assertEquals(test.expectedDelta, actual, "While testing case: " + test.s1 + ", " + test.s2);
         }
     }
 
     @Test
-    void delta() {
-        // NOTE: we are testing both delta and percent here, because they are so closely related.
-        Case[] tests = {
-            new Case("uwu", "owo", 2, 2 / (double) 3),
-            new Case("horse", "ros", 3, 3 / (double) 5),
-            new Case("intention", "execution", 5, 5 / (double) 9),
-            new Case("uwu", "", 3, 1),
-            new Case("", "uwu", 3, 1),
-            new Case("   ", "uwu", 3, 1),
-            new Case("foo", "baz bat", 7, 1),
-            new Case("uwu", "uwu", 0, 0)
-        };
-
-        for (Case test : tests) {
-            int actual = Fuzzy.delta(test.a, test.b);
-            assertEquals(test.expectedDelta, actual, "While testing case: " + test.a + ", " + test.b);
+    void ratio() {
+        for (TestCase test : testCases) {
+            double actual = Fuzzy.ratio(test.s1, test.s2);
+            assertEquals(test.expectedRatio, actual, 0.0001, "While testing case: " + test.s1 + ", " + test.s2);
         }
     }
 }

--- a/src/test/java/mycelium/mycelium/testutil/Pair.java
+++ b/src/test/java/mycelium/mycelium/testutil/Pair.java
@@ -43,4 +43,12 @@ public class Pair<A, B> {
     public int hashCode() {
         return Objects.hash(first, second);
     }
+
+    @Override
+    public String toString() {
+        return "Pair{" +
+            "first=" + first +
+            ", second=" + second +
+            '}';
+    }
 }

--- a/src/test/java/mycelium/mycelium/testutil/Pair.java
+++ b/src/test/java/mycelium/mycelium/testutil/Pair.java
@@ -46,9 +46,6 @@ public class Pair<A, B> {
 
     @Override
     public String toString() {
-        return "Pair{" +
-            "first=" + first +
-            ", second=" + second +
-            '}';
+        return "Pair{" + "first=" + first + ", second=" + second + '}';
     }
 }


### PR DESCRIPTION
Closes #128, closes #129, and closes #112.

## Main changes

* Introduces a `FuzzyManager` class to handle the fuzzy stuff
* Updates constructor for `CommandBox` to take two consumers. They are executed when its state toggles between listening and notlistening.

## Why are we creating new lists?

In `FuzzyManager#onInputChanged`, we can see that new (wrapper) lists are created from the original ones obtained from address book after the fuzzy matching and sorting. These new lists are then applied to `MainWindow`.

This is needed since we need need to **sort** the items. JavaFX allows this through the `SortedList` type which is immutable, unlike a `FilteredList` where we can reset the predicate. Thus we have no choice but to create a new `SortedList` each time, and apply it onto `MainWindow`