### PR TITLE
Handle edge case where updated fields change nothing

### DIFF
--- a/src/test/java/mycelium/mycelium/logic/commands/UpdateProjectCommandTest.java
+++ b/src/test/java/mycelium/mycelium/logic/commands/UpdateProjectCommandTest.java
@@ -138,7 +138,7 @@ public class UpdateProjectCommandTest {
     @Test
     public void execute_allFieldsSameExceptName_success() throws CommandException {
         var cmd = new UpdateProjectCommand(BING.getName(),
-            new UpdateProjectDescriptorBuilder(BARD).withName(BARD.getName()).build());
+            new UpdateProjectDescriptorBuilder(BING).withName(BARD.getName()).build());
         model.addProject(BING);
         cmd.execute(model);
 

--- a/src/test/java/mycelium/mycelium/logic/commands/UpdateProjectCommandTest.java
+++ b/src/test/java/mycelium/mycelium/logic/commands/UpdateProjectCommandTest.java
@@ -119,4 +119,30 @@ public class UpdateProjectCommandTest {
         var got2 = model.getUniqueProject(p -> p.isSame(BING));
         assertFalse(got2.isPresent());
     }
+
+    @Test
+    public void execute_nameRemainsTheSame_throwsCommandException() {
+        var cmd = new UpdateProjectCommand(BING.getName(),
+            new UpdateProjectDescriptorBuilder().withName(BING.getName()).build());
+        model.addProject(BING);
+        assertThrows(CommandException.class, UpdateProjectCommand.MESSAGE_NOT_UPDATED, () -> cmd.execute(model));
+    }
+
+    @Test
+    public void execute_allFieldsRemainTheSame_throwsCommandException() {
+        var cmd = new UpdateProjectCommand(BING.getName(), new UpdateProjectDescriptorBuilder(BING).build());
+        model.addProject(BING);
+        assertThrows(CommandException.class, UpdateProjectCommand.MESSAGE_NOT_UPDATED, () -> cmd.execute(model));
+    }
+
+    @Test
+    public void execute_allFieldsSameExceptName_success() throws CommandException {
+        var cmd = new UpdateProjectCommand(BING.getName(),
+            new UpdateProjectDescriptorBuilder(BARD).withName(BARD.getName()).build());
+        model.addProject(BING);
+        cmd.execute(model);
+
+        assertFalse(model.hasProject(BING)); // BING should not be in the model
+        assertTrue(model.hasProject(BARD)); // BARD should be in the model
+    }
 }

--- a/src/test/java/mycelium/mycelium/logic/parser/UpdateProjectCommandParserTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/UpdateProjectCommandParserTest.java
@@ -89,6 +89,15 @@ public class UpdateProjectCommandParserTest {
     }
 
     @Test
+    public void parse_oldAndNewNamesIdentical_success() {
+        // This tests what happens if we give a command to update a project's name, but then give it back the same name
+        var descriptor = new UpdateProjectDescriptorBuilder().withName("foobar").build();
+        var input = " -pn foobar -pn2 foobar";
+        var want = new UpdateProjectCommand(new NonEmptyString("foobar"), descriptor);
+        assertParseSuccess(parser, input, want);
+    }
+
+    @Test
     public void parse_invalidArgfollowedByValidArg_success() {
         var descriptor = new UpdateProjectCommand.UpdateProjectDescriptor();
         descriptor.setName(new NonEmptyString("barfoo"));


### PR DESCRIPTION
Before, we didn't handle commands like

```
up -pn foobar -pn2 foobar
```

correctly. This fixes that and adds tests to verify.