### PR TITLE
Change fuzzy search implementation

### DIFF
--- a/src/main/java/mycelium/mycelium/model/FuzzyManager.java
+++ b/src/main/java/mycelium/mycelium/model/FuzzyManager.java
@@ -1,29 +1,53 @@
 package mycelium.mycelium.model;
 
-import java.util.logging.Logger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import mycelium.mycelium.commons.core.LogsCenter;
+import mycelium.mycelium.model.util.Fuzzy;
 import mycelium.mycelium.model.util.FuzzyComparable;
 
 /**
  * This class is responsible for handling fuzzy matching of clients and projects.
  */
 public class FuzzyManager {
-    private static final Logger logger = LogsCenter.getLogger(FuzzyManager.class);
-
     /**
      * Given an {@code ObservableList} of {@code FuzzyComparable} items and a query, returns a new list of items
      * ranked by their fuzzy match score with the query.
      */
     public static <T extends FuzzyComparable<String>> ObservableList<T> rankItems(ObservableList<T> items,
                                                                                   String query) {
+        query = query.strip().toLowerCase();
         if (query.isEmpty()) {
             return items;
         }
-        logger.fine("Received fuzzy match request for items with query = " + query);
-        return items.filtered(item -> item.fuzzyCompareTo(query) > 0.0)
-            .sorted((item1, item2) -> Double.compare(item2.fuzzyCompareTo(query), item1.fuzzyCompareTo(query)));
+
+        HashMap<T, Double> simpleScores = new HashMap<>();
+        for (T item : items) {
+            simpleScores.put(item, Fuzzy.delta(query, item.getFuzzyField().toLowerCase()));
+        }
+
+        Map<Boolean, List<T>> partitioned =
+            items.stream().collect(Collectors.partitioningBy(item -> simpleScores.get(item) > 0.0));
+        List<T> results = partitioned.get(true);
+        List<T> remaining = partitioned.get(false);
+
+        HashMap<T, Double> distances = new HashMap<>();
+        for (T item : remaining) {
+            distances.put(item, Fuzzy.levenshtein(query, item.getFuzzyField().toLowerCase()));
+        }
+
+        results.sort((item1, item2) -> Double.compare(simpleScores.get(item2), simpleScores.get(item1)));
+
+        remaining.stream()
+            .filter(item -> distances.get(item) > 0.0)
+            .sorted((item1, item2) -> Double.compare(distances.get(item2), distances.get(item1)))
+            .forEach(results::add);
+
+        return FXCollections.observableArrayList(results);
     }
 }
 

--- a/src/main/java/mycelium/mycelium/model/client/Client.java
+++ b/src/main/java/mycelium/mycelium/model/client/Client.java
@@ -148,8 +148,7 @@ public class Client implements IsSame<Client>, FuzzyComparable<String> {
     }
 
     @Override
-    public double fuzzyCompareTo(String match) {
-        var ret = Fuzzy.ratio(name.toString().toLowerCase(), match.toLowerCase());
-        return ret;
+    public String getFuzzyField() {
+        return name.fullName;
     }
 }

--- a/src/main/java/mycelium/mycelium/model/client/Client.java
+++ b/src/main/java/mycelium/mycelium/model/client/Client.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import mycelium.mycelium.model.person.Email;
 import mycelium.mycelium.model.person.Name;
 import mycelium.mycelium.model.person.Phone;
-import mycelium.mycelium.model.util.Fuzzy;
 import mycelium.mycelium.model.util.FuzzyComparable;
 import mycelium.mycelium.model.util.IsSame;
 import mycelium.mycelium.model.util.NonEmptyString;

--- a/src/main/java/mycelium/mycelium/model/project/Project.java
+++ b/src/main/java/mycelium/mycelium/model/project/Project.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import mycelium.mycelium.model.person.Email;
-import mycelium.mycelium.model.util.Fuzzy;
 import mycelium.mycelium.model.util.FuzzyComparable;
 import mycelium.mycelium.model.util.IsSame;
 import mycelium.mycelium.model.util.NonEmptyString;
@@ -139,10 +138,8 @@ public class Project implements IsSame<Project>, FuzzyComparable<String> {
      * deadline is the same, ties will be broken using name.
      *
      * @param other The other project
-     * @return 0 if two projects are equal with regards to {@code equals}
-     *          1 if this project has deadline after the given project or with same deadline but the name is
-     *          topologically smaller
-     *          -1 for the rest
+     * @return 0 if two projects are equal with regards to {@code equals} * 1 if this project has deadline after the
+     *         given project or with same deadline but the name is * topologically smaller * -1 for the rest
      */
     public int compareToWithDeadline(Project other) {
         LocalDate thisDeadline = this.getDeadline().get();

--- a/src/main/java/mycelium/mycelium/model/project/Project.java
+++ b/src/main/java/mycelium/mycelium/model/project/Project.java
@@ -193,8 +193,8 @@ public class Project implements IsSame<Project>, FuzzyComparable<String> {
     }
 
     @Override
-    public double fuzzyCompareTo(String match) {
-        return Fuzzy.ratio(name.toString().toLowerCase(), match.toLowerCase());
+    public String getFuzzyField() {
+        return name.getValue();
     }
 }
 

--- a/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
+++ b/src/main/java/mycelium/mycelium/model/util/Fuzzy.java
@@ -4,12 +4,53 @@ package mycelium.mycelium.model.util;
  * A utility class for fuzzy string matching.
  */
 public class Fuzzy {
+    /**
+     * Returns a value between 0 and 1, where 0 means the two strings are "completely different", and 1 means they are
+     * completely the same. Every character in the query must be present in the target, and the characters must be in
+     * the
+     * same order.
+     */
+    public static double delta(String query, String target) {
+        // An empty query would match everything, so we disallow it and return 0. Since we expect every character of
+        // the query to be present in the target, we also disallow the case where the query is longer than the target.
+        if (target.length() < query.length() || query.isEmpty()) {
+            return 0;
+        }
+
+        double score = 0;
+        int targetIdx = 0;
+
+        // Skip over characters in the target until we find the first character of the query.
+        targetIdx += target.chars().takeWhile(x -> x != query.charAt(0)).count(); // fancy stream
+        if (targetIdx == target.length()) {
+            return 0;
+        }
+        score += targetIdx;
+        targetIdx++;
+
+        for (int i = 1; i < query.length(); i++) {
+            int prevTargetIdx = targetIdx;
+
+            while (targetIdx < target.length() && target.charAt(targetIdx) != query.charAt(i)) {
+                targetIdx++;
+            }
+            if (targetIdx == target.length()) {
+                return 0;
+            }
+
+            score += 3 * (targetIdx - prevTargetIdx); // note the multiplier
+            targetIdx++;
+        }
+
+        score += target.length() - targetIdx;
+        return 1 / (score + 1); // prevent division by 0
+    }
 
     /**
      * Computes a "delta-score" between two strings. The lower the score, the more similar the strings are. A score
-     * of zero means the strings are completely identical.
+     * of zero means the strings are completely identical. This is just levenshtein distance.
      */
-    public static int delta(String a, String b) {
+    private static int distance(String a, String b) {
         // The intuitive way to do this is through a m-by-n matrix. Here we are only
         // using one array and a temp variable.
         int m = a.length();
@@ -74,10 +115,9 @@ public class Fuzzy {
     }
 
     /**
-     * Computes a "delta-score" between two strings, and returns a value between 0 and 1, where 0 means the two strings
-     * are completely different, and 1 means they are completely the same.
+     * Computes distance between two strings as a ratio. The higher the ratio, the more similar the strings are.
      */
-    public static double ratio(String a, String b) {
-        return 1 - (double) delta(a, b) / Math.max(a.length(), b.length());
+    public static double levenshtein(String a, String b) {
+        return 1 - (double) distance(a, b) / Math.max(a.length(), b.length());
     }
 }

--- a/src/main/java/mycelium/mycelium/model/util/FuzzyComparable.java
+++ b/src/main/java/mycelium/mycelium/model/util/FuzzyComparable.java
@@ -8,11 +8,7 @@ package mycelium.mycelium.model.util;
  */
 public interface FuzzyComparable<T> {
     /**
-     * Returns a value between 0 and 1, where 0 means the two objects are
-     * completely different, and 1 means they are completely the same.
-     *
-     * @param other The other object to compare to.
-     * @return A value between 0 and 1.
+     * Retrieves a string that will be used for fuzzy matching.
      */
-    double fuzzyCompareTo(T other);
+    String getFuzzyField();
 }

--- a/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
+++ b/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
@@ -33,7 +33,7 @@ class FuzzyTest {
             new TestCase("foo", "foobar", 1 / (double) (3 + 1)), // trailing fluff
             new TestCase("foo", "barfoobar", 1 / (double) (6 + 1)), // leading and trailing fluff
             new TestCase("foo", "fooooo", 1 / (double) (3 + 1)), // repeated characters
-            new TestCase("foo", "fxoxxo", 1 / (double) (2 + 4 + 1)), // interleaved characters
+            new TestCase("foo", "fxoxxo", 1 / (double) (3 + 6 + 1)), // interleaved characters
         };
         for (TestCase test : testCases) {
             double actual = Fuzzy.delta(test.query, test.target);

--- a/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
+++ b/src/test/java/mycelium/mycelium/model/util/FuzzyTest.java
@@ -10,43 +10,53 @@ class FuzzyTest {
      * A test case for the delta function.
      */
     private static class TestCase {
-        public final String s1;
-        public final String s2;
-        public final int expectedDelta;
-        public final double expectedRatio;
+        public final String query;
+        public final String target;
+        public final double expectedDelta;
 
-        TestCase(String s1, String s2, int expectedDelta, double expectedRatio) {
-            this.s1 = s1;
-            this.s2 = s2;
+        TestCase(String query, String target, double expectedDelta) {
+            this.query = query;
+            this.target = target;
             this.expectedDelta = expectedDelta;
-            this.expectedRatio = expectedRatio;
         }
     }
-
-    private static final TestCase[] testCases = {
-        new TestCase("uwu", "owo", 2, 1 / (double) 3),
-        new TestCase("horse", "ros", 3, 2 / (double) 5),
-        new TestCase("intention", "execution", 5, 4 / (double) 9),
-        new TestCase("uwu", "", 3, 0),
-        new TestCase("", "uwu", 3, 0),
-        new TestCase("   ", "uwu", 3, 0),
-        new TestCase("foo", "baz bat", 7, 0),
-        new TestCase("uwu", "uwu", 0, 1)
-    };
 
     @Test
     void delta() {
+        TestCase[] testCases = {
+            new TestCase("foo", "bar", 0), // completely no match
+            new TestCase("foo", "foo", 1), // exact match
+            new TestCase("", "foo", 0), // empty query
+            new TestCase("foo", "", 0), // empty target
+            new TestCase("foobar", "", 0), // query longer than target
+            new TestCase("foo", "barfoo", 1 / (double) (3 + 1)), // leading fluff
+            new TestCase("foo", "foobar", 1 / (double) (3 + 1)), // trailing fluff
+            new TestCase("foo", "barfoobar", 1 / (double) (6 + 1)), // leading and trailing fluff
+            new TestCase("foo", "fooooo", 1 / (double) (3 + 1)), // repeated characters
+            new TestCase("foo", "fxoxxo", 1 / (double) (2 + 4 + 1)), // interleaved characters
+        };
         for (TestCase test : testCases) {
-            int actual = Fuzzy.delta(test.s1, test.s2);
-            assertEquals(test.expectedDelta, actual, "While testing case: " + test.s1 + ", " + test.s2);
+            double actual = Fuzzy.delta(test.query, test.target);
+            assertEquals(test.expectedDelta, actual, 0.0001, "While testing case: " + test.query + ", " + test.target);
         }
     }
 
     @Test
-    void ratio() {
+    void levenshtein() {
+        TestCase[] testCases = {
+            new TestCase("uwu", "owo", 1 / (double) 3),
+            new TestCase("horse", "ros", 2 / (double) 5),
+            new TestCase("intention", "execution", 4 / (double) 9),
+            new TestCase("uwu", "", 0),
+            new TestCase("", "uwu", 0),
+            new TestCase("   ", "uwu", 0),
+            new TestCase("foo", "baz bat", 0),
+            new TestCase("uwu", "uwu", 1)
+        };
+
         for (TestCase test : testCases) {
-            double actual = Fuzzy.ratio(test.s1, test.s2);
-            assertEquals(test.expectedRatio, actual, 0.0001, "While testing case: " + test.s1 + ", " + test.s2);
+            double actual = Fuzzy.levenshtein(test.query, test.target);
+            assertEquals(test.expectedDelta, actual, 0.0001, "While testing case: " + test.query + ", " + test.target);
         }
     }
 }


### PR DESCRIPTION
Done in two passes now. First pass is more strict
and looks for the query as a subsequence of
the target.

The second pass is performed on those which
failed the first pass, and is the same as before.