### PR TITLE
Handle case where project name is -pn2 literal

### DIFF
--- a/src/main/java/mycelium/mycelium/commons/core/Messages.java
+++ b/src/main/java/mycelium/mycelium/commons/core/Messages.java
@@ -14,5 +14,9 @@ public class Messages {
 
     public static final String MESSAGE_EMPTY_PROJECT_NAME =
         "Project name cannot be empty or consist of only whitespace";
+    public static final String
+        MESSAGE_ILLEGAL_PROJECT_NAME_FMT =
+        "'%s' is an illegal project name as it interferes with parsing. Please consider differentiating it from an "
+            + "argument flag.";
     public static final String MESSAGE_EMPTY_SOURCE = "Source cannot be empty or consist of only whitespace";
 }

--- a/src/main/java/mycelium/mycelium/logic/parser/ParserUtil.java
+++ b/src/main/java/mycelium/mycelium/logic/parser/ParserUtil.java
@@ -24,6 +24,9 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
+    /* Some project names are illegal as they interfere with parsing */
+    public static final String[] ILLEGAL_PROJECT_NAMES = {"-pn2"};
+
     /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
@@ -110,11 +113,20 @@ public class ParserUtil {
      * Parses a string into a {@code NonEmptyString} representing a project name.
      */
     public static NonEmptyString parseProjectName(String source) throws ParseException {
+        NonEmptyString name;
         try {
-            return parseNonEmptyString(source);
+            name = parseNonEmptyString(source);
         } catch (ParseException e) {
             throw new ParseException(Messages.MESSAGE_EMPTY_PROJECT_NAME);
         }
+
+        // some project names may cause problems down the line, so we check them here
+        for (String bannedName : ILLEGAL_PROJECT_NAMES) {
+            if (name.equals(bannedName)) {
+                throw new ParseException(String.format(Messages.MESSAGE_ILLEGAL_PROJECT_NAME_FMT, name));
+            }
+        }
+        return name;
     }
 
     /**

--- a/src/test/java/mycelium/mycelium/logic/parser/ParserUtilTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/ParserUtilTest.java
@@ -240,4 +240,12 @@ public class ParserUtilTest {
             Assertions.assertEquals(want, ParserUtil.parseLocalDate(tt, Project.DATE_FMT));
         }
     }
+
+    @Test
+    public void parseProjectName_illegalValue_throwsParseException() {
+        for (var name : ParserUtil.ILLEGAL_PROJECT_NAMES) {
+            var msg = String.format(Messages.MESSAGE_ILLEGAL_PROJECT_NAME_FMT, name);
+            Assert.assertThrows(ParseException.class, msg, () -> ParserUtil.parseProjectName(name));
+        }
+    }
 }


### PR DESCRIPTION
Pretty hacky solution but I think it's good
enough for now. Maintain a list of illegal
project names, and each time a project name is
parsed, check if it is inside the list.

Fixes #198 