### PR TITLE
Bug fixes for parser

### DIFF
--- a/src/test/java/mycelium/mycelium/logic/parser/AddProjectCommandParserTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/AddProjectCommandParserTest.java
@@ -36,8 +36,6 @@ public class AddProjectCommandParserTest {
             Map.entry("has email prefix only, but no whitespace", "-ejamal@hogriders.org"),
 
             Map.entry("prefixes are not separated", "-pn-e"),
-            Map.entry("no name nor email", "-pn -e"),
-            Map.entry("name, but no email", "-pn Bing -e"),
             Map.entry("name and email not separated", "-pnBing-ejamal@hogriders.org")
         );
         String expectedOutput =
@@ -60,6 +58,8 @@ public class AddProjectCommandParserTest {
                 Pair.of("-pn  -e jamal@hogriders.org", Messages.MESSAGE_EMPTY_PROJECT_NAME)),
             Map.entry("invalid email (whitespace)",
                 Pair.of("-pn Bing -e ", Email.MESSAGE_CONSTRAINTS)),
+            Map.entry("invalid email (empty as last arg)",
+                Pair.of("-pn Bing -e", Email.MESSAGE_CONSTRAINTS)),
             Map.entry("invalid email",
                 Pair.of("-pn Bing -e foobar", Email.MESSAGE_CONSTRAINTS)),
 

--- a/src/test/java/mycelium/mycelium/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/ArgumentTokenizerTest.java
@@ -14,6 +14,8 @@ public class ArgumentTokenizerTest {
     private final Prefix dashT = new Prefix("-t");
     private final Prefix hatQ = new Prefix("^Q");
 
+    private final Prefix dashSrc = new Prefix("-src "); // note the whitespace
+
     @Test
     public void tokenize_emptyArgsString_noValues() {
         String argsString = "  ";
@@ -145,6 +147,13 @@ public class ArgumentTokenizerTest {
 
         assertNotEquals(aaa, "aaa");
         assertNotEquals(aaa, new Prefix("aab"));
+    }
+
+    @Test
+    public void tokenize_prefixAtBackWithWhitespace() {
+        var argString = "... -src foobar -src";
+        var got = ArgumentTokenizer.tokenize(argString, dashSrc);
+        assertArgumentPresent(got, dashSrc, "foobar", "");
     }
 
 }

--- a/src/test/java/mycelium/mycelium/logic/parser/DeleteClientCommandParserTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/DeleteClientCommandParserTest.java
@@ -20,10 +20,9 @@ public class DeleteClientCommandParserTest {
 
     @Test
     public void parse_missingRequiredArgs_fails() {
-        Map<String, String> tests = Map.ofEntries(
-            Map.entry("empty string", ""),
-            Map.entry("only whitespace", " "),
-            Map.entry("no email", "-e")
+        Map<String, String> tests = Map.of(
+            "empty string", "",
+            "only whitespace", " "
         );
         String expectedErr = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeleteClientCommand.MESSAGE_USAGE);
         tests.forEach((desc, tt) -> {
@@ -34,9 +33,10 @@ public class DeleteClientCommandParserTest {
 
     @Test
     public void parse_invalidEmail_fails() {
-        Map<String, String> tests = Map.ofEntries(
-            Map.entry("email is whitespace", "-e "),
-            Map.entry("invalid email", "-e foobar")
+        Map<String, String> tests = Map.of(
+            "email is whitespace", "-e ",
+            "email is empty", "-e",
+            "invalid email", "-e foobar"
         );
         tests.forEach((desc, tt) -> {
             String input = " " + tt;
@@ -47,10 +47,10 @@ public class DeleteClientCommandParserTest {
     @Test
     public void parse_validEmail_success() {
         DeleteClientCommand want = new DeleteClientCommand(new Email("jamal@hogriders.org"));
-        Map<String, String> tests = Map.ofEntries(
-            Map.entry("valid email", "-e jamal@hogriders.org"),
-            Map.entry("valid email with trailing whitespace", "-e jamal@hogriders.org   "),
-            Map.entry("multiple emails", "-e jamar@hogriders.org -e jamal@hogriders.org")
+        Map<String, String> tests = Map.of(
+            "valid email", "-e jamal@hogriders.org",
+            "valid email with trailing whitespace", "-e jamal@hogriders.org   ",
+            "multiple emails", "-e jamar@hogriders.org -e jamal@hogriders.org"
         );
         tests.forEach((desc, tt) -> {
             String input = " " + tt;

--- a/src/test/java/mycelium/mycelium/logic/parser/DeleteProjectCommandParserTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/DeleteProjectCommandParserTest.java
@@ -21,10 +21,9 @@ public class DeleteProjectCommandParserTest {
 
     @Test
     public void parse_missingRequiredArgs_fails() {
-        Map<String, String> tests = Map.ofEntries(
-            Map.entry("empty string", ""),
-            Map.entry("only whitespace", " "),
-            Map.entry("no project name", "-pn")
+        Map<String, String> tests = Map.of(
+            "empty string", "",
+            "only whitespace", " "
         );
         String expectedErr = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeleteProjectCommand.MESSAGE_USAGE);
         tests.forEach((desc, tt) -> {
@@ -35,10 +34,10 @@ public class DeleteProjectCommandParserTest {
 
     @Test
     public void parse_wrongArgs_fails() {
-        Map<String, String> tests = Map.ofEntries(
-            Map.entry("delete project by email", "-e alicebaker@gmail.com"),
-            Map.entry("wrong prefix for project name", "-n Luminus"),
-            Map.entry("delete project by client name", "-cn NUS")
+        Map<String, String> tests = Map.of(
+            "delete project by email", "-e alicebaker@gmail.com",
+            "wrong prefix for project name", "-n Luminus",
+            "delete project by client name", "-cn NUS"
         );
         String expectedErr = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeleteProjectCommand.MESSAGE_USAGE);
         tests.forEach((desc, tt) -> {
@@ -50,10 +49,10 @@ public class DeleteProjectCommandParserTest {
     @Test
     public void parse_validProjectName_success() {
         DeleteProjectCommand want = new DeleteProjectCommand(NonEmptyString.of("Luminus"));
-        Map<String, String> tests = Map.ofEntries(
-            Map.entry("valid project name", "-pn Luminus"),
-            Map.entry("valid project name with leading whitespace", "-pn       Luminus"),
-            Map.entry("valid project name with trailing whitespace", "-pn Luminus      ")
+        Map<String, String> tests = Map.of(
+            "valid project name", "-pn Luminus",
+            "valid project name with leading whitespace", "-pn       Luminus",
+            "valid project name with trailing whitespace", "-pn Luminus      "
         );
         tests.forEach((desc, tt) -> {
             String input = " " + tt;

--- a/src/test/java/mycelium/mycelium/logic/parser/UpdateClientCommandParserTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/UpdateClientCommandParserTest.java
@@ -34,7 +34,6 @@ public class UpdateClientCommandParserTest {
     @Test
     public void parse_missingRequiredArgs_throwsParseException() {
         assertParseFailure(parser, " -cn 123131", MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, " -e", MESSAGE_INVALID_FORMAT);
     }
 
     @Test

--- a/src/test/java/mycelium/mycelium/logic/parser/UpdateProjectCommandParserTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/UpdateProjectCommandParserTest.java
@@ -30,8 +30,6 @@ public class UpdateProjectCommandParserTest {
     public void parse_missingRequiredArgs_throwsParseException() {
         // required arg not given
         assertParseFailure(parser, " -dd 31/12/2023", MESSAGE_INVALID_FORMAT);
-        // require arg flag present, but no value
-        assertParseFailure(parser, " -pn", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
@@ -40,6 +38,7 @@ public class UpdateProjectCommandParserTest {
             "-pn2   ", Messages.MESSAGE_EMPTY_PROJECT_NAME,
             "-s notastatus", ProjectStatus.MESSAGE_CONSTRAINTS,
             "-e notanemail", Email.MESSAGE_CONSTRAINTS,
+            "-e", Email.MESSAGE_CONSTRAINTS,
             "-src  ", Messages.MESSAGE_EMPTY_SOURCE,
             "-ad 31-12-2023", Messages.MESSAGE_INVALID_DATE,
             "-dd 31-12-2023", Messages.MESSAGE_INVALID_DATE

--- a/src/test/java/mycelium/mycelium/model/project/ProjectStatusTest.java
+++ b/src/test/java/mycelium/mycelium/model/project/ProjectStatusTest.java
@@ -15,21 +15,21 @@ import org.junit.jupiter.api.Test;
 import mycelium.mycelium.testutil.Pair;
 
 public class ProjectStatusTest {
-    private static final Map<String, Pair<String, ProjectStatus>> okInput = Map.ofEntries(
-        Map.entry("not started", Pair.of("not_started", NOT_STARTED)),
-        Map.entry("in progress", Pair.of("in_progress", IN_PROGRESS)),
-        Map.entry("done", Pair.of("done", DONE)),
-        Map.entry("not started (uppercase)", Pair.of("NOT_STARTED", NOT_STARTED)),
-        Map.entry("in progress (uppercase)", Pair.of("IN_PROGRESS", IN_PROGRESS)),
-        Map.entry("done (uppercase)", Pair.of("DONE", DONE)),
-        Map.entry("not started (mixed case)", Pair.of("NoT_sTaRtEd", NOT_STARTED)),
-        Map.entry("in progress (mixed case)", Pair.of("In_PrOgReSs", IN_PROGRESS)),
-        Map.entry("done (mixed case)", Pair.of("dOnE", DONE))
+    private static final Map<String, Pair<String, ProjectStatus>> okInput = Map.of(
+        "not started", Pair.of("not_started", NOT_STARTED),
+        "in progress", Pair.of("in_progress", IN_PROGRESS),
+        "done", Pair.of("done", DONE),
+        "not started (uppercase)", Pair.of("NOT_STARTED", NOT_STARTED),
+        "in progress (uppercase)", Pair.of("IN_PROGRESS", IN_PROGRESS),
+        "done (uppercase)", Pair.of("DONE", DONE),
+        "not started (mixed case)", Pair.of("NoT_sTaRtEd", NOT_STARTED),
+        "in progress (mixed case)", Pair.of("In_PrOgReSs", IN_PROGRESS),
+        "done (mixed case)", Pair.of("dOnE", DONE)
     );
-    private static final Map<String, String> badInput = Map.ofEntries(
-        Map.entry("empty string", ""),
-        Map.entry("only whitespace", " "),
-        Map.entry("invalid status", "foobar")
+    private static final Map<String, String> badInput = Map.of(
+        "empty string", "",
+        "only whitespace", " ",
+        "invalid status", "foobar"
     );
 
     @Test


### PR DESCRIPTION
Closes #245.

Treat this as an edge case when parsing. Abit of a hacky solution tho. Functionality changes in this patch are only in ArgumentTokenizer.java

Also fixed some tests which failed due to this update, and refactored some others for neatness.

<img width="273" alt="image" src="https://user-images.githubusercontent.com/47441677/229841028-8e4e697a-c8c2-40f4-9301-b3715bab282b.png">

Error message is like that now. Previously, it would read *-src* as part of the email.