### PR TITLE
Refactor null and validity check and added note regarding data tampering in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -972,3 +972,10 @@ The terms in this glossary are sorted in alphabetical order.
 
 {TODO maybe add}
 
+--------------------------------------------------------------------------------------------------------------------
+
+## Appendix: Planned Enhancements
+1. [ ] Utilising checksum on JSON file to prevent manual tampering of data.
+1. [ ] Displaying explicit exceptions when the JSON file is corrupted or tampered with.
+
+

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedClient.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedClient.java
@@ -21,10 +21,8 @@ import mycelium.mycelium.model.util.NonEmptyString;
  * {@code Client} object for deserialization. It also contains methods for null and validity checks of the adapted
  * client object's fields.
  */
-class JsonAdaptedClient {
-
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Client's %s field is missing!";
-
+class JsonAdaptedClient extends JsonAdaptedEntity {
+    private static final String ENTITY_NAME = "Client";
     private final String name;
     private final String email;
     private final String yearOfBirth;
@@ -39,6 +37,7 @@ class JsonAdaptedClient {
                              @JsonProperty("year_of_birth") String yearOfBirth,
                              @JsonProperty("source") String source,
                              @JsonProperty("mobile_number") String mobileNumber) {
+        super(ENTITY_NAME);
         this.name = name;
         this.email = email;
         this.yearOfBirth = yearOfBirth;
@@ -50,37 +49,12 @@ class JsonAdaptedClient {
      * Converts a given {@code Client} into this class for Jackson use.
      */
     public JsonAdaptedClient(Client client) {
+        super(ENTITY_NAME);
         name = client.getName().fullName;
         email = client.getEmail().value;
         yearOfBirth = client.getYearOfBirth().map(x -> x.value).orElse(null);
         source = client.getSource().map(NonEmptyString::toString).orElse(null);
         mobileNumber = client.getMobileNumber().map(x -> x.value).orElse(null);
-    }
-
-    /**
-     * Throws an {@code IllegalValueException} with the given message if the given boolean is true.
-     *
-     * @param check         The boolean to be checked.
-     * @param attributeName The name of the attribute being checked.
-     * @throws IllegalValueException if the given boolean is true.
-     */
-    public void nullCheck(boolean check, String attributeName) throws IllegalValueException {
-        if (check) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, attributeName));
-        }
-    }
-
-    /**
-     * Throws an {@code IllegalValueException} with the given message if the boolean is true.
-     *
-     * @param check   The boolean to be checked.
-     * @param message The error message to be displayed if the check fails.
-     * @throws IllegalValueException if the given boolean is true.
-     */
-    public void validityCheck(boolean check, String message) throws IllegalValueException {
-        if (check) {
-            throw new IllegalValueException(message);
-        }
     }
 
     /**
@@ -90,19 +64,19 @@ class JsonAdaptedClient {
      * @throws IllegalValueException if there were any data constraints violated in the adapted client.
      */
     public Client toModelType() throws IllegalValueException {
-        nullCheck(name == null, Name.class.getSimpleName());
-        validityCheck(!Name.isValidName(name), Name.MESSAGE_CONSTRAINTS);
+        nullCheck(name, Name.class.getSimpleName());
+        validityCheck(Name.isValidName(name), Name.MESSAGE_CONSTRAINTS);
         final Name modelName = new Name(name);
 
-        nullCheck(email == null, Email.class.getSimpleName());
-        validityCheck(!Email.isValidEmail(email), Email.MESSAGE_CONSTRAINTS);
+        nullCheck(email, Email.class.getSimpleName());
+        validityCheck(Email.isValidEmail(email), Email.MESSAGE_CONSTRAINTS);
         final Email modelEmail = new Email(email);
 
         if (yearOfBirth != null) {
-            validityCheck(!YearOfBirth.isValidYearOfBirth(yearOfBirth), YearOfBirth.MESSAGE_CONSTRAINTS);
+            validityCheck(YearOfBirth.isValidYearOfBirth(yearOfBirth), YearOfBirth.MESSAGE_CONSTRAINTS);
         }
         if (mobileNumber != null) {
-            validityCheck(!Phone.isValidPhone(mobileNumber), Phone.MESSAGE_CONSTRAINTS);
+            validityCheck(Phone.isValidPhone(mobileNumber), Phone.MESSAGE_CONSTRAINTS);
         }
 
         return new Client(modelName,

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedEntity.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedEntity.java
@@ -2,6 +2,9 @@ package mycelium.mycelium.storage;
 
 import mycelium.mycelium.commons.exceptions.IllegalValueException;
 
+/**
+ * Represents a generic entity that can be stored in JSON.
+ */
 public abstract class JsonAdaptedEntity {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "%s's %s field is missing!";
     private String entityName;

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedEntity.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedEntity.java
@@ -1,0 +1,38 @@
+package mycelium.mycelium.storage;
+
+import mycelium.mycelium.commons.exceptions.IllegalValueException;
+
+public abstract class JsonAdaptedEntity {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "%s's %s field is missing!";
+    private String entityName;
+
+    public JsonAdaptedEntity(String entityName) {
+        this.entityName = entityName;
+    }
+
+    /**
+     * Throws an {@code IllegalValueException} with the given message if the {@code obj} is null.
+     *
+     * @param obj           the object to be checked.
+     * @param attributeName The name of the attribute being checked.
+     * @throws IllegalValueException if the given boolean is true.
+     */
+    protected void nullCheck(Object obj, String attributeName) throws IllegalValueException {
+        if (obj == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, entityName, attributeName));
+        }
+    }
+
+    /**
+     * Throws an {@code IllegalValueException} with the given message if the boolean is false.
+     *
+     * @param check   The boolean to be checked.
+     * @param message The error message to be displayed if the check fails.
+     * @throws IllegalValueException if the given boolean is true.
+     */
+    protected void validityCheck(boolean check, String message) throws IllegalValueException {
+        if (!check) {
+            throw new IllegalValueException(message);
+        }
+    }
+}

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
@@ -17,7 +17,7 @@ import mycelium.mycelium.model.util.NonEmptyString;
 /**
  * Jackson friendly version of {@link Project}.
  */
-public class JsonAdaptedProject extends JsonAdaptedEntity{
+public class JsonAdaptedProject extends JsonAdaptedEntity {
     private static final String ENTITY_NAME = "Project";
     private final String name;
     private final ProjectStatus status;
@@ -71,10 +71,10 @@ public class JsonAdaptedProject extends JsonAdaptedEntity{
      * @throws IllegalValueException if some null fields exist
      */
     public Project toModelType() throws IllegalValueException {
-        nullCheck(name != null, "name");
-        nullCheck(status != null, "status");
-        nullCheck(clientEmail != null, "clientEmail");
-        nullCheck(acceptedOn != null, "acceptedOn");
+        nullCheck(name, "name");
+        nullCheck(status, "status");
+        nullCheck(clientEmail, "clientEmail");
+        nullCheck(acceptedOn, "acceptedOn");
         // NOTE: it is okay for the deadline and description to be null
         return new Project(NonEmptyString.of(name),
             status,

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
@@ -17,8 +17,8 @@ import mycelium.mycelium.model.util.NonEmptyString;
 /**
  * Jackson friendly version of {@link Project}.
  */
-public class JsonAdaptedProject {
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Project's %s field is missing";
+public class JsonAdaptedProject extends JsonAdaptedEntity{
+    private static final String ENTITY_NAME = "Project";
     private final String name;
     private final ProjectStatus status;
     private final String clientEmail;
@@ -40,6 +40,7 @@ public class JsonAdaptedProject {
                               @JsonProperty("description") String description,
                               @JsonProperty("acceptedOn") LocalDate acceptedOn,
                               @JsonProperty("deadline") LocalDate deadline) {
+        super(ENTITY_NAME);
         this.name = name;
         this.status = status;
         this.clientEmail = clientEmail;
@@ -53,6 +54,7 @@ public class JsonAdaptedProject {
      * Constructs this class from a vanilla {@link Project}.
      */
     public JsonAdaptedProject(Project project) {
+        super(ENTITY_NAME);
         name = project.getName().toString();
         status = project.getStatus();
         clientEmail = project.getClientEmail().value;
@@ -62,12 +64,6 @@ public class JsonAdaptedProject {
         deadline = project.getDeadline().orElse(null);
     }
 
-    private static void assertField(boolean cond, String fieldName) throws IllegalValueException {
-        if (!cond) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, fieldName));
-        }
-    }
-
     /**
      * Constructs a {@link Project} from this class.
      *
@@ -75,10 +71,10 @@ public class JsonAdaptedProject {
      * @throws IllegalValueException if some null fields exist
      */
     public Project toModelType() throws IllegalValueException {
-        assertField(name != null, "name");
-        assertField(status != null, "status");
-        assertField(clientEmail != null, "clientEmail");
-        assertField(acceptedOn != null, "acceptedOn");
+        nullCheck(name != null, "name");
+        nullCheck(status != null, "status");
+        nullCheck(clientEmail != null, "clientEmail");
+        nullCheck(acceptedOn != null, "acceptedOn");
         // NOTE: it is okay for the deadline and description to be null
         return new Project(NonEmptyString.of(name),
             status,

--- a/src/test/java/mycelium/mycelium/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/mycelium/mycelium/storage/JsonAdaptedClientTest.java
@@ -60,7 +60,10 @@ public class JsonAdaptedClientTest {
             VALID_SOURCE, VALID_MOBILE_NUMBER);
         String
             expectedMessage =
-            String.format(JsonAdaptedClient.MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
+            String.format(
+                JsonAdaptedEntity.MISSING_FIELD_MESSAGE_FORMAT,
+                Client.class.getSimpleName(),
+                Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
@@ -79,7 +82,10 @@ public class JsonAdaptedClientTest {
             VALID_SOURCE, VALID_MOBILE_NUMBER);
         String
             expectedMessage =
-            String.format(JsonAdaptedClient.MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
+            String.format(
+                JsonAdaptedEntity.MISSING_FIELD_MESSAGE_FORMAT,
+                Client.class.getSimpleName(),
+                Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 

--- a/src/test/java/mycelium/mycelium/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/mycelium/mycelium/storage/JsonAdaptedProjectTest.java
@@ -49,7 +49,7 @@ public class JsonAdaptedProjectTest {
     public void toModelType_invalidNullFields_throwsIllegalValueException() {
         // Convenience lambda to build the expected error message
         UnaryOperator<String> withErr = (fieldName)
-            -> String.format(JsonAdaptedProject.MISSING_FIELD_MESSAGE_FORMAT, fieldName);
+            -> String.format(JsonAdaptedEntity.MISSING_FIELD_MESSAGE_FORMAT, Project.class.getSimpleName(), fieldName);
 
         // A bunch of test cases with varying null fields. It is rather verbose, but there is no working
         // around it, since we would like to simulate Jackson's behavior of instantiating this class.


### PR DESCRIPTION
Did some refactoring for JSONSerialisableClient and JSONSerialisableProject so they extend from abstract class JSONSerialisableEntity. Allows reuse of nullCheck and validityCheck.

Added `Planned Enhancements` section in DG to describe how to handle the 2 issues being closed by the PR

Closes #242, Closes #243