### PR TITLE
Refactor localdate validation

### DIFF
--- a/src/main/java/mycelium/mycelium/commons/util/DateUtil.java
+++ b/src/main/java/mycelium/mycelium/commons/util/DateUtil.java
@@ -2,48 +2,64 @@ package mycelium.mycelium.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.time.temporal.TemporalAdjusters;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 
 
 /**
  * A class for Date utility functions.
  */
-public class DateUtil {
+public class DateUtil extends JsonDeserializer<LocalDate> {
+    /**
+     * Parses dates in the dd/MM/uuuu format. Range of allowed years is [-9999, 9999].
+     */
+    public static final DateTimeFormatter DATE_FMT =
+        DateTimeFormatter.ofPattern("dd/MM/uuuu").withResolverStyle(ResolverStyle.STRICT);
+
     /**
      * Checks if the {@code date} is within this or next week.
      * Week is counted as starting from Sunday.
      *
      * @param date cannot be null
-     * @return true if the {@code date} is within this or next week.
-     *          false otherwise.
+     * @return true if the {@code date} is within this or next week, or false otherwise.
      */
     public static boolean isWithinThisAndNextWeek(LocalDate date) {
         requireNonNull(date);
         assert date != null;
         LocalDate currentDate = LocalDate.now();
         LocalDate startOfCurrentWeek =
-                currentDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+            currentDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
         LocalDate endOfNextWeek =
-                startOfCurrentWeek.plusDays(13);
+            startOfCurrentWeek.plusDays(13);
 
         return (date.isAfter(startOfCurrentWeek) || date.isEqual(startOfCurrentWeek))
-                && (date.isEqual(endOfNextWeek) || date.isBefore(endOfNextWeek));
+            && (date.isEqual(endOfNextWeek) || date.isBefore(endOfNextWeek));
     }
 
     /**
      * Checks if {@code date} is before current date.
      *
      * @param date cannot be null
-     * @return true if {@code date} is before current time.
-     *          false otherwise.
+     * @return true if {@code date} is before current time, or false otherwise.
      */
     public static boolean isBeforeToday(LocalDate date) {
         requireNonNull(date);
         LocalDate currentDate = LocalDate.now();
 
         return date.isBefore(currentDate);
+    }
+
+    @Override
+    public LocalDate deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getValueAsString();
+        return LocalDate.parse(value, DATE_FMT);
     }
 }

--- a/src/main/java/mycelium/mycelium/logic/parser/AddProjectCommandParser.java
+++ b/src/main/java/mycelium/mycelium/logic/parser/AddProjectCommandParser.java
@@ -12,6 +12,7 @@ import static mycelium.mycelium.logic.parser.CliSyntax.PREFIX_SOURCE;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.logic.commands.AddProjectCommand;
 import mycelium.mycelium.logic.parser.exceptions.ParseException;
 import mycelium.mycelium.model.client.Email;
@@ -52,7 +53,7 @@ public class AddProjectCommandParser implements Parser<AddProjectCommand> {
             : ProjectStatus.NOT_STARTED;
         Optional<String> maybeAcceptedOn = argMultimap.getValue(PREFIX_ACCEPTED_DATE);
         LocalDate acceptedOn = maybeAcceptedOn.isPresent()
-            ? ParserUtil.parseLocalDate(maybeAcceptedOn.get(), Project.DATE_FMT)
+            ? ParserUtil.parseLocalDate(maybeAcceptedOn.get(), DateUtil.DATE_FMT)
             : LocalDate.now();
 
         Optional<NonEmptyString> source = ParserUtil.parseOptionalWith(
@@ -62,7 +63,7 @@ public class AddProjectCommandParser implements Parser<AddProjectCommand> {
         Optional<String> description = argMultimap.getValue(PREFIX_PROJECT_DESCRIPTION);
         Optional<LocalDate> deadline = ParserUtil.parseOptionalWith(
             argMultimap.getValue(PREFIX_DEADLINE_DATE),
-            d -> ParserUtil.parseLocalDate(d, Project.DATE_FMT));
+            d -> ParserUtil.parseLocalDate(d, DateUtil.DATE_FMT));
 
         Project
             project =

--- a/src/main/java/mycelium/mycelium/logic/parser/UpdateProjectCommandParser.java
+++ b/src/main/java/mycelium/mycelium/logic/parser/UpdateProjectCommandParser.java
@@ -12,9 +12,9 @@ import static mycelium.mycelium.logic.parser.CliSyntax.PREFIX_PROJECT_STATUS;
 import static mycelium.mycelium.logic.parser.CliSyntax.PREFIX_SOURCE;
 import static mycelium.mycelium.logic.parser.ParserUtil.parseOptionalWith;
 
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.logic.commands.UpdateProjectCommand;
 import mycelium.mycelium.logic.parser.exceptions.ParseException;
-import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.model.util.NonEmptyString;
 
 /**
@@ -47,9 +47,9 @@ public class UpdateProjectCommandParser implements Parser<UpdateProjectCommand> 
         var source = parseOptionalWith(argMultimap.getValue(PREFIX_SOURCE), ParserUtil::parseSource);
         var description = argMultimap.getValue(PREFIX_PROJECT_DESCRIPTION);
         var acceptedOn = parseOptionalWith(argMultimap.getValue(PREFIX_ACCEPTED_DATE),
-            s -> ParserUtil.parseLocalDate(s, Project.DATE_FMT));
+            s -> ParserUtil.parseLocalDate(s, DateUtil.DATE_FMT));
         var deadline = parseOptionalWith(argMultimap.getValue(PREFIX_DEADLINE_DATE),
-            s -> ParserUtil.parseLocalDate(s, Project.DATE_FMT));
+            s -> ParserUtil.parseLocalDate(s, DateUtil.DATE_FMT));
 
         UpdateProjectCommand.UpdateProjectDescriptor desc = new UpdateProjectCommand.UpdateProjectDescriptor();
         desc.setName(newName);

--- a/src/main/java/mycelium/mycelium/model/project/Project.java
+++ b/src/main/java/mycelium/mycelium/model/project/Project.java
@@ -3,8 +3,6 @@ package mycelium.mycelium.model.project;
 import static mycelium.mycelium.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.ResolverStyle;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -17,11 +15,6 @@ import mycelium.mycelium.model.util.NonEmptyString;
  * Represents a project.
  */
 public class Project implements IsSame<Project>, FuzzyComparable<String> {
-    /**
-     * Parses dates in the dd/MM/uuuu format. Range of allowed years is [-9999, 9999].
-     */
-    public static final DateTimeFormatter DATE_FMT =
-        DateTimeFormatter.ofPattern("dd/MM/uuuu").withResolverStyle(ResolverStyle.STRICT);
 
     /**
      * The project's name

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
@@ -7,8 +7,10 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import mycelium.mycelium.commons.exceptions.IllegalValueException;
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.model.client.Email;
 import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.model.project.ProjectStatus;
@@ -24,9 +26,11 @@ public class JsonAdaptedProject {
     private final String clientEmail;
     private final String source;
     private final String description;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/uuuu")
+    @JsonDeserialize(using = DateUtil.class)
     private final LocalDate acceptedOn;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/uuuu")
+    @JsonDeserialize(using = DateUtil.class)
     private final LocalDate deadline; // NOTE: it is okay for the deadline to be null
 
     /**
@@ -82,7 +86,7 @@ public class JsonAdaptedProject {
         // NOTE: it is okay for the deadline and description to be null
         return new Project(NonEmptyString.of(name),
             status,
-            new Email(clientEmail),
+            new Email(clientEmail), // constructor will validate for us
             NonEmptyString.ofOptional(source),
             Optional.ofNullable(description),
             acceptedOn,

--- a/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
+++ b/src/main/java/mycelium/mycelium/storage/JsonAdaptedProject.java
@@ -79,10 +79,18 @@ public class JsonAdaptedProject extends JsonAdaptedEntity {
         nullCheck(status, "status");
         nullCheck(clientEmail, "clientEmail");
         nullCheck(acceptedOn, "acceptedOn");
+
+        // NOTE: validity checks for status, acceptedOn, and deadline are done in the constructor
+        validityCheck(NonEmptyString.isValid(name), "name");
+        validityCheck(Email.isValidEmail(clientEmail), "clientEmail");
+        if (source != null) {
+            validityCheck(NonEmptyString.isValid(source), "source");
+        }
+
         // NOTE: it is okay for the deadline and description to be null
         return new Project(NonEmptyString.of(name),
             status,
-            new Email(clientEmail), // constructor will validate for us
+            new Email(clientEmail),
             NonEmptyString.ofOptional(source),
             Optional.ofNullable(description),
             acceptedOn,

--- a/src/main/java/mycelium/mycelium/ui/entitypanel/ProjectEntity.java
+++ b/src/main/java/mycelium/mycelium/ui/entitypanel/ProjectEntity.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import mycelium.mycelium.commons.core.LogsCenter;
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.model.util.NonEmptyString;
 import mycelium.mycelium.ui.UiPart;
@@ -56,8 +57,8 @@ public class ProjectEntity extends UiPart<Region> {
         email.setText(p.getClientEmail().toString());
         source.setText(p.getSource().map(NonEmptyString::toString).orElse("Unknown"));
         description.setText(p.getDescription().orElse("No description given"));
-        acceptedOn.setText(p.getAcceptedOn().format(Project.DATE_FMT));
-        deadline.setText(p.getDeadline().map(d -> d.format(Project.DATE_FMT)).orElse("No Deadline"));
+        acceptedOn.setText(p.getAcceptedOn().format(DateUtil.DATE_FMT));
+        deadline.setText(p.getDeadline().map(d -> d.format(DateUtil.DATE_FMT)).orElse("No Deadline"));
         logger.fine("Initialized ProjectEntity with project: " + p.getName());
     }
 

--- a/src/main/java/mycelium/mycelium/ui/statisticsbox/SpecialProjectEntity.java
+++ b/src/main/java/mycelium/mycelium/ui/statisticsbox/SpecialProjectEntity.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import mycelium.mycelium.commons.core.LogsCenter;
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.ui.UiPart;
 
@@ -47,7 +48,7 @@ public class SpecialProjectEntity extends UiPart<Region> {
         name.setText(p.getName().getValue());
         status.setText(p.getStatus().toString());
         email.setText(p.getClientEmail().toString());
-        deadline.setText(p.getDeadline().map(d -> d.format(Project.DATE_FMT)).orElse("No Deadline"));
+        deadline.setText(p.getDeadline().map(d -> d.format(DateUtil.DATE_FMT)).orElse("No Deadline"));
         logger.fine("Initialized SpecialProjectEntity with project: " + p.getName());
     }
 

--- a/src/test/java/mycelium/mycelium/logic/parser/ParserUtilTest.java
+++ b/src/test/java/mycelium/mycelium/logic/parser/ParserUtilTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import mycelium.mycelium.commons.core.Messages;
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.logic.parser.exceptions.ParseException;
 import mycelium.mycelium.model.client.Email;
 import mycelium.mycelium.model.client.Name;
 import mycelium.mycelium.model.client.Phone;
 import mycelium.mycelium.model.client.YearOfBirth;
-import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.model.project.ProjectStatus;
 import mycelium.mycelium.model.util.NonEmptyString;
 import mycelium.mycelium.testutil.Assert;
@@ -192,7 +192,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseLocalDate_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseLocalDate(null, Project.DATE_FMT));
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseLocalDate(null, DateUtil.DATE_FMT));
     }
 
     @Test
@@ -221,7 +221,7 @@ public class ParserUtilTest {
         );
         tests.forEach((key, value) -> {
             Assert.assertThrows(ParseException.class,
-                Messages.MESSAGE_INVALID_DATE, () -> ParserUtil.parseLocalDate(value, Project.DATE_FMT));
+                Messages.MESSAGE_INVALID_DATE, () -> ParserUtil.parseLocalDate(value, DateUtil.DATE_FMT));
         });
     }
 
@@ -236,8 +236,8 @@ public class ParserUtilTest {
             "01/01/-9999"
         };
         for (String tt : tests) {
-            LocalDate want = LocalDate.parse(tt, Project.DATE_FMT);
-            Assertions.assertEquals(want, ParserUtil.parseLocalDate(tt, Project.DATE_FMT));
+            LocalDate want = LocalDate.parse(tt, DateUtil.DATE_FMT);
+            Assertions.assertEquals(want, ParserUtil.parseLocalDate(tt, DateUtil.DATE_FMT));
         }
     }
 

--- a/src/test/java/mycelium/mycelium/testutil/ProjectBuilder.java
+++ b/src/test/java/mycelium/mycelium/testutil/ProjectBuilder.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.model.client.Email;
 import mycelium.mycelium.model.project.Project;
 import mycelium.mycelium.model.project.ProjectStatus;
@@ -145,7 +146,7 @@ public class ProjectBuilder {
      * Sets the project's deadline using a string representation of a date.
      */
     public ProjectBuilder withDeadline(String dateStr) {
-        this.deadline = LocalDate.parse(dateStr, Project.DATE_FMT);
+        this.deadline = LocalDate.parse(dateStr, DateUtil.DATE_FMT);
         return this;
     }
 

--- a/src/test/java/mycelium/mycelium/testutil/UpdateProjectDescriptorBuilder.java
+++ b/src/test/java/mycelium/mycelium/testutil/UpdateProjectDescriptorBuilder.java
@@ -3,6 +3,7 @@ package mycelium.mycelium.testutil;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.logic.commands.UpdateProjectCommand;
 import mycelium.mycelium.model.client.Email;
 import mycelium.mycelium.model.project.Project;
@@ -88,7 +89,7 @@ public class UpdateProjectDescriptorBuilder {
      * Sets the project's acceptedOn date of the {@code UpdateProjectDescriptor} that we are building.
      */
     public UpdateProjectDescriptorBuilder withAcceptedOn(String acceptedOn) {
-        descriptor.setAcceptedOn(Optional.ofNullable(acceptedOn).map(s -> LocalDate.parse(s, Project.DATE_FMT)));
+        descriptor.setAcceptedOn(Optional.ofNullable(acceptedOn).map(s -> LocalDate.parse(s, DateUtil.DATE_FMT)));
         return this;
     }
 
@@ -96,7 +97,7 @@ public class UpdateProjectDescriptorBuilder {
      * Sets the project's deadline of the {@code UpdateProjectDescriptor} that we are building.
      */
     public UpdateProjectDescriptorBuilder withDeadline(String deadline) {
-        descriptor.setDeadline(Optional.ofNullable(deadline).map(s -> LocalDate.parse(s, Project.DATE_FMT)));
+        descriptor.setDeadline(Optional.ofNullable(deadline).map(s -> LocalDate.parse(s, DateUtil.DATE_FMT)));
         return this;
     }
 

--- a/src/test/java/mycelium/mycelium/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/mycelium/mycelium/ui/testutil/GuiTestAssert.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import guitests.guihandles.ClientListCardHandle;
 import guitests.guihandles.ProjectListCardHandle;
 import guitests.guihandles.SpecialProjectListCardHandle;
+import mycelium.mycelium.commons.util.DateUtil;
 import mycelium.mycelium.model.client.Client;
 import mycelium.mycelium.model.client.Phone;
 import mycelium.mycelium.model.client.YearOfBirth;
@@ -26,7 +27,7 @@ public class GuiTestAssert {
         assertEquals(
             expectedProject
                 .getDeadline()
-                .map(d -> d.format(Project.DATE_FMT))
+                .map(d -> d.format(DateUtil.DATE_FMT))
                 .orElse("No Deadline"),
             actualCard.getDeadline());
     }
@@ -40,11 +41,11 @@ public class GuiTestAssert {
         assertEquals(expectedProject.getClientEmail().value, actualCard.getClientEmail());
         assertEquals(expectedProject.getSource().map(NonEmptyString::getValue).orElse("Unknown"),
                 actualCard.getSource());
-        assertEquals(expectedProject.getAcceptedOn().format(Project.DATE_FMT), actualCard.getAcceptedOn());
+        assertEquals(expectedProject.getAcceptedOn().format(DateUtil.DATE_FMT), actualCard.getAcceptedOn());
         assertEquals(
                 expectedProject
                         .getDeadline()
-                        .map(d -> d.format(Project.DATE_FMT))
+                        .map(d -> d.format(DateUtil.DATE_FMT))
                         .orElse("No Deadline"),
                 actualCard.getDeadline());
         assertEquals(expectedProject.getDescription().orElse("No description given"), actualCard.getDescription());


### PR DESCRIPTION
Previously, there was no validation for
localdate when deserializing a project. This
commit moves the date formatter to our DateUtil
class, and uses it within the JsonAdaptedProject.

Fixes #242 