### PR TITLE
Fix wrong validation of updated project and client

### DIFF
--- a/src/main/java/mycelium/mycelium/logic/commands/UpdateClientCommand.java
+++ b/src/main/java/mycelium/mycelium/logic/commands/UpdateClientCommand.java
@@ -109,7 +109,9 @@ public class UpdateClientCommand extends Command {
             throw new CommandException(MESSAGE_NOT_EDITED, action);
         }
         // Ensures that new email is not a mandatory option
-        if (updateClientDescriptor.email.isPresent() && model.hasClient(updatedClient.get())) {
+        if (updateClientDescriptor.email.isPresent()
+            && model.hasClient(updatedClient.get())
+            && !uniqueClient.get().isSame(updatedClient.get())) {
             throw new CommandException(MESSAGE_DUPLICATE_CLIENT, action);
         }
         model.setClient(uniqueClient.get(), updatedClient.get());

--- a/src/main/java/mycelium/mycelium/logic/commands/UpdateProjectCommand.java
+++ b/src/main/java/mycelium/mycelium/logic/commands/UpdateProjectCommand.java
@@ -135,9 +135,12 @@ public class UpdateProjectCommand extends Command {
         if (updatedProject.isEmpty()) {
             throw new CommandException(MESSAGE_NOT_UPDATED, action);
         }
-        if (desc.name.isPresent() && model.hasProject(updatedProject.get())) {
+        if (desc.name.isPresent()
+            && model.hasProject(updatedProject.get())
+            && !target.get().isSame(updatedProject.get())) {
             throw new CommandException(MESSAGE_DUPLICATE_PROJECT, action);
         }
+
         model.setProject(target.get(), updatedProject.get());
         return new CommandResult(String.format(MESSAGE_UPDATE_PROJECT_SUCCESS, updatedProject.get()), action);
     }

--- a/src/test/java/mycelium/mycelium/logic/commands/UpdateClientCommandTest.java
+++ b/src/test/java/mycelium/mycelium/logic/commands/UpdateClientCommandTest.java
@@ -112,6 +112,21 @@ public class UpdateClientCommandTest {
     }
 
     @Test
+    public void execute_sameEmailButOtherChanges_success() {
+        var cmd = new UpdateClientCommand(WEST.getEmail(),
+            new UpdateClientDescriptorBuilder(NEW_DESC).withEmail(WEST.getEmail()).build());
+        model.addClient(WEST);
+
+        var updatedClient = new ClientBuilder(RANTARO).withEmail(WEST.getEmail()).build();
+        var expMsg = String.format(UpdateClientCommand.MESSAGE_SUCCESS, updatedClient);
+        var expRes = buildCommandResult.apply(expMsg);
+        var expModel = new ModelManager();
+        expModel.addClient(updatedClient);
+
+        assertCommandSuccess(cmd, model, expRes, expModel);
+    }
+
+    @Test
     public void equals() {
         UpdateClientCommand.UpdateClientDescriptor desc1 = new UpdateClientCommand.UpdateClientDescriptor();
         UpdateClientCommand.UpdateClientDescriptor desc2 = new UpdateClientCommand.UpdateClientDescriptor();

--- a/src/test/java/mycelium/mycelium/logic/commands/UpdateProjectCommandTest.java
+++ b/src/test/java/mycelium/mycelium/logic/commands/UpdateProjectCommandTest.java
@@ -156,4 +156,19 @@ public class UpdateProjectCommandTest {
         assertFalse(model.hasProject(BING)); // BING should not be in the model
         assertTrue(model.hasProject(BARD)); // BARD should be in the model
     }
+
+    @Test
+    public void execute_sameNameButOtherChanges_success() {
+        var cmd = new UpdateProjectCommand(BARD.getName(),
+            new UpdateProjectDescriptorBuilder(BING).withName(BARD.getName()).build());
+        model.addProject(BARD);
+
+        var updatedProject = new ProjectBuilder(BING).withName(BARD.getName()).build();
+        var expMsg = String.format(UpdateProjectCommand.MESSAGE_UPDATE_PROJECT_SUCCESS, updatedProject);
+        var expRes = buildCommandResult.apply(expMsg);
+        var expModel = new ModelManager();
+        expModel.addProject(updatedProject);
+
+        assertCommandSuccess(cmd, model, expRes, expModel);
+    }
 }

--- a/src/test/java/mycelium/mycelium/testutil/UpdateClientDescriptorBuilder.java
+++ b/src/test/java/mycelium/mycelium/testutil/UpdateClientDescriptorBuilder.java
@@ -20,6 +20,13 @@ public class UpdateClientDescriptorBuilder {
     }
 
     /**
+     * Copies the given {@code descriptor} into a new {@code UpdateClientDescriptorBuilder}.
+     */
+    public UpdateClientDescriptorBuilder(UpdateClientCommand.UpdateClientDescriptor descriptor) {
+        this.descriptor = new UpdateClientCommand.UpdateClientDescriptor(descriptor);
+    }
+
+    /**
      * Creates a new {@code UpdateClientDescriptorBuilder} with the fields of the given {@code descriptor} copied.
      *
      * @param name the name of the client.
@@ -38,6 +45,14 @@ public class UpdateClientDescriptorBuilder {
      */
     public UpdateClientDescriptorBuilder withEmail(String email) {
         descriptor.setEmail(Optional.ofNullable(email).map(Email::new));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Email} of the {@code UpdateClientDescriptorBuilder} that we are building.
+     */
+    public UpdateClientDescriptorBuilder withEmail(Email email) {
+        descriptor.setEmail(Optional.ofNullable(email));
         return this;
     }
 


### PR DESCRIPTION
Previously, updating a project's name back to
its own name was wrongly blocked.

Fixes #240 