### PR TITLE
Fix entity selection with mouse

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -699,7 +699,7 @@ is selected when the project's box is coloured blue, as shown below.
 
 ![step2](images/SearchAndSelectStep2.png)
 
-You can then press (ENTER) to switch back to **command mode** and append the project name to the command box. The project's name will be highlighted (this is not shown in the screenshot below due to to limitations of the screenshot program).
+You can then press (ENTER) to switch back to **command mode** and append the project name to the command box. The project's name will be highlighted (this is not shown in the screenshot below due to limitations of the screenshot program).
 
 ![step3](images/SearchAndSelectStep3.png)
 
@@ -707,12 +707,6 @@ We can now proceed to execute the command as per usual. Note that for clients,
 the (ENTER) key would extract the client's email. This way you can quickly
 reference a project or client in your command, without having to type out the
 full name or email.
-
-<div markdown="span" class="alert alert-danger">
-:warning: Avoid using your mouse to select a project or client. Instead, use
-the (CTRL+J) and (CTRL+K) hotkeys. Using a mouse to select a project or client
-is not officially supported by Mycelium.
-</div>
 
 ### Fuzzy search Gotchas
 

--- a/src/main/java/mycelium/mycelium/logic/uievent/UiEventManager.java
+++ b/src/main/java/mycelium/mycelium/logic/uievent/UiEventManager.java
@@ -9,6 +9,7 @@ import javafx.scene.input.KeyEvent;
 import mycelium.mycelium.logic.Logic;
 import mycelium.mycelium.logic.uievent.key.ClearKey;
 import mycelium.mycelium.logic.uievent.key.EndOfLineKey;
+import mycelium.mycelium.logic.uievent.key.EnterKey;
 import mycelium.mycelium.logic.uievent.key.FindKey;
 import mycelium.mycelium.logic.uievent.key.HelpKey;
 import mycelium.mycelium.logic.uievent.key.NextItemKey;
@@ -70,6 +71,7 @@ public class UiEventManager implements UiEvent {
      * @param event the key event
      */
     public void catchAndExecute(KeyEvent event) {
+        mainWindow.focusCommandBox();
         if (isIgnored(event)) {
 
         } else if (HelpKey.KEY_COMBINATION.match(event)) {
@@ -92,8 +94,9 @@ public class UiEventManager implements UiEvent {
             new EndOfLineKey().execute(logic, mainWindow);
         } else if (QuitKey.KEY_COMBINATION.match(event)) {
             new QuitKey().execute(logic, mainWindow);
+        } else if (EnterKey.KEY_COMBINATION.match(event)) {
+            new EnterKey().execute(logic, mainWindow);
         } else {
-            mainWindow.focusCommandBox();
             return;
         }
         event.consume();

--- a/src/main/java/mycelium/mycelium/logic/uievent/key/EnterKey.java
+++ b/src/main/java/mycelium/mycelium/logic/uievent/key/EnterKey.java
@@ -1,0 +1,19 @@
+package mycelium.mycelium.logic.uievent.key;
+
+import javafx.scene.input.KeyCombination;
+import mycelium.mycelium.logic.Logic;
+import mycelium.mycelium.ui.MainWindow;
+
+/**
+ * EnterKey is a key combination that submits the command in the command box.
+ *
+ * This is to created to allow submission regardless of command box focus.
+ */
+public class EnterKey extends Key {
+    public static final KeyCombination KEY_COMBINATION = KeyCombination.valueOf("Enter");
+
+    @Override
+    public void execute(Logic logic, MainWindow mainWindow) {
+        mainWindow.forceCommandBoxSubmit();
+    }
+}

--- a/src/main/java/mycelium/mycelium/ui/MainWindow.java
+++ b/src/main/java/mycelium/mycelium/ui/MainWindow.java
@@ -286,6 +286,15 @@ public class MainWindow extends UiPart<Stage> {
         commandBox.requestFocus();
     }
 
+    /**
+     * Forces the command box to submit the command.
+     *
+     * @see CommandBox#handleCommandEntered()
+     */
+    public void forceCommandBoxSubmit() {
+        commandBox.handleInputSubmit();
+    }
+
     // CommandLog methods ======================================================
     /**
      * Sets the feedback to the user.

--- a/src/main/java/mycelium/mycelium/ui/commandbox/CommandBox.java
+++ b/src/main/java/mycelium/mycelium/ui/commandbox/CommandBox.java
@@ -37,7 +37,7 @@ public class CommandBox extends UiPart<Region> {
      * Handles the Enter button pressed event.
      */
     @FXML
-    private void handleCommandEntered() {
+    public void handleInputSubmit() {
         Optional<Mode> nextMode = mode.onInputSubmit(commandTextField.getText());
         if (nextMode.isPresent()) {
             setMode(nextMode.get());
@@ -85,9 +85,16 @@ public class CommandBox extends UiPart<Region> {
 
     /**
      * Requests focus on the command box.
+     *
+     * If the command box is already focused, this method does nothing.
+     * Otherwise, the command box will be focused and the cursor will be moved to the end of the line.
      */
     public void requestFocus() {
+        if (commandTextField.isFocused()) {
+            return;
+        }
         commandTextField.requestFocus();
+        moveToEndOfLine();
     }
 
     /**

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" onKeyTyped="#handleInputChange" promptText="Enter command here..." />
+  <TextField fx:id="commandTextField" onAction="#handleInputSubmit" onKeyTyped="#handleInputChange" promptText="Enter command here..." />
 </StackPane>


### PR DESCRIPTION
Previously, selecting entity with mouse will unfocus on the command box. With the way `UiEventManager` was implemented, the `CommandBox` will be brought into focus whenever a key is pressed. This led to `Enter` refocusing on command box to the start of line, which somehow led to the whole box being highlighted.

This has been fix now as every key press will send refocus to command box if not already focused and position the caret at the end of the text only when refocusing is done. This prevents the highlighting of the whole command box when refocusing on command box.

Previously, selecting eneity with mouse in command box and pressing enter creates a odd behaviour where the command box is filled with reference before quickly being cleared again. This has been fix by creating a `EnterKey` key binds which forces input submission when enter is pressed regardless of focus. This allows the selection of entity made with mouse to be utilised despite a selection with mouse unfocuses from the command box.

Closes #239