### PR TITLE
Add note in UG and DG about data corruption

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -194,6 +194,13 @@ The `Storage` component,
 * inherits from both `AddressBookStorage` and `UserPrefStorage`, which means it can be treated as either one (if only the functionality of only one is needed).
 * depends on some classes in the `Model` component (because the `Storage` component's job is to save/retrieve objects that belong to the `Model`)
 
+<div markdown="span" class="alert alert-danger">
+:warning: If the JSON file storing the data becomes unreadable or invalid due to corruption or tampering,
+Mycelium will ignore the data file and start an empty application with no projects and clients. Commands
+performed that will modify the data file will overwrite the corrupted file. This would lead to a
+complete and unrecoverable loss of data prior to the corruption.
+</div>
+
 ### Common classes
 
 Classes used by multiple components are in the `mycelium.mycelium.commons` package.
@@ -931,5 +938,13 @@ with (ENTER).
 --------------------------------------------------------------------------------------------------------------------
 
 ## Appendix: Planned Enhancements
-1. [ ] Utilising checksum on JSON file to prevent manual tampering of data.
-1. [ ] Displaying explicit exceptions when the JSON file is corrupted or tampered with.
+1. Utilising checksum on JSON file to prevent manual tampering of data and display explicit exceptions when the JSON file is corrupted or tampered with.
+   * A checksum could be generated in `checksum.txt` in the same directory as the JSON file.
+   * Any modification to the JSON file would result in a different checksum, which can be
+      detected by comparing with the checksum stored in `checksum.txt`.
+   * If the checksums do not match or is missing, the user will be notified about 
+      a possible corruption in their data and be prompted to restore the JSON file from a backup.
+   * The JSON file will then proceed to be read by Mycelium. If the JSON file is unreadable or 
+      contains invalid values, the JSON file will be ignored and the application will start as an
+      empty application with no projects and clients.
+   * Possible checksum algorithms are MD5, SHA-1, SHA-256, SHA-512.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -74,6 +74,14 @@ to help you get a feel for the application. Feel free to delete them later.
 
 <img src="images/OnStartupScreenshot.png" />
 
+<div markdown="span" class="alert alert-danger">
+:warning: As you perform commands in Mycelium, you will notice that a
+new data file `mycelium.json` is created in `data/` directory as the default.
+Corruption or tampering with it may lead to the data file becoming unreadable
+or containing invalid values. This will result in the the file being ignored
+and Mycelium will start as an empty application with no projects and clients.
+</div>
+
 You may resize the window to your liking. At this point, we recommend that you
 jump over to the [UI Overview](#ui-overview) or [Command
 Summary](#command-summary) sections to get an overview of the commands which


### PR DESCRIPTION
Added note in UG and DG to warn users about corrupting data in the JSON file. Do help me vet and make sure my wording is right.

Explained in more detail how Checksum could be implemented in `Planned Enhancement` section of appendix

Closes #243 